### PR TITLE
Fix stale pending user-input after session restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,14 @@
 - All of `bun fmt`, `bun lint`, and `bun typecheck` must pass before considering tasks completed.
 - NEVER run `bun test`. Always use `bun run test` (runs Vitest).
 
+## Bun Gotcha
+
+- In this environment, `bun` may not be on `PATH` even though Bun is installed at `/home/claude/.bun/bin/bun`.
+- If plain `bun ...` fails with `bun: command not found`, use the absolute binary path instead.
+- For `bun typecheck`, also prepend Bun to `PATH` so Turbo can find the package manager binary:
+  `env PATH="/home/claude/.bun/bin:$PATH" /home/claude/.bun/bin/bun typecheck`
+- `bun fmt` and `bun lint` can be run directly with `/home/claude/.bun/bin/bun fmt` and `/home/claude/.bun/bin/bun lint`.
+
 ## Project Snapshot
 
 T3 Code is a minimal web GUI for using code agents like Codex and Claude Code (coming soon).

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -713,6 +713,117 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("surfaces stale provider user-input failures with a clear recovery message", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    harness.respondToUserInput.mockImplementation(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: "codex",
+          method: "item/tool/requestUserInput",
+          detail: "Unknown pending user input request: user-input-request-1",
+        }),
+      ),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-for-user-input-error"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.makeUnsafe("cmd-user-input-requested"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        activity: {
+          id: EventId.makeUnsafe("activity-user-input-requested"),
+          tone: "info",
+          kind: "user-input.requested",
+          summary: "User input requested",
+          payload: {
+            requestId: "user-input-request-1",
+            questions: [
+              {
+                id: "sandbox_mode",
+                header: "Sandbox",
+                question: "Which mode should be used?",
+                options: [
+                  {
+                    label: "workspace-write",
+                    description: "Allow workspace writes only",
+                  },
+                ],
+              },
+            ],
+          },
+          turnId: null,
+          createdAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.user-input.respond",
+        commandId: CommandId.makeUnsafe("cmd-user-input-respond-stale"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        requestId: asApprovalRequestId("user-input-request-1"),
+        answers: {
+          sandbox_mode: "workspace-write",
+        },
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find(
+        (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
+      );
+      if (!thread) return false;
+      return thread.activities.some(
+        (activity) => activity.kind === "provider.user-input.respond.failed",
+      );
+    });
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+    expect(thread).toBeDefined();
+
+    const failureActivity = thread?.activities.find(
+      (activity) => activity.kind === "provider.user-input.respond.failed",
+    );
+    expect(failureActivity?.payload).toMatchObject({
+      requestId: "user-input-request-1",
+      detail:
+        "This question came from an earlier provider session and expired after the session restarted. Please ask the agent to re-ask the question.",
+    });
+
+    const resolvedActivity = thread?.activities.find(
+      (activity) =>
+        activity.kind === "user-input.resolved" &&
+        typeof activity.payload === "object" &&
+        activity.payload !== null &&
+        (activity.payload as Record<string, unknown>).requestId === "user-input-request-1",
+    );
+    expect(resolvedActivity).toBeUndefined();
+  });
+
   it("surfaces stale provider approval request failures without faking approval resolution", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -90,6 +90,28 @@ function isUnknownPendingApprovalRequestError(cause: Cause.Cause<ProviderService
   );
 }
 
+function isStalePendingUserInputError(cause: Cause.Cause<ProviderServiceError>): boolean {
+  const error = Cause.squash(cause);
+  if (Schema.is(ProviderAdapterRequestError)(error)) {
+    return error.detail.toLowerCase().includes("unknown pending user input request");
+  }
+  const message = Cause.pretty(cause).toLowerCase();
+  return (
+    message.includes("unknown pending user input request") ||
+    message.includes("belongs to a previous provider session")
+  );
+}
+
+function describePendingUserInputFailure(cause: Cause.Cause<ProviderServiceError>): string {
+  if (isStalePendingUserInputError(cause)) {
+    return (
+      "This question came from an earlier provider session and expired after the session restarted. " +
+      "Please ask the agent to re-ask the question."
+    );
+  }
+  return Cause.pretty(cause);
+}
+
 function isTemporaryWorktreeBranch(branch: string): boolean {
   return TEMP_WORKTREE_BRANCH_PATTERN.test(branch.trim().toLowerCase());
 }
@@ -578,7 +600,7 @@ const make = Effect.gen(function* () {
             threadId: event.payload.threadId,
             kind: "provider.user-input.respond.failed",
             summary: "Provider user input response failed",
-            detail: Cause.pretty(cause),
+            detail: describePendingUserInputFailure(cause),
             turnId: null,
             createdAt: event.payload.createdAt,
             requestId: event.payload.requestId,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -493,6 +493,42 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect("fails fast for user input replies after the provider session is gone", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+
+      const session = yield* provider.startSession(asThreadId("thread-user-input-stale"), {
+        provider: "codex",
+        threadId: asThreadId("thread-user-input-stale"),
+        runtimeMode: "full-access",
+      });
+      yield* routing.codex.stopSession(session.threadId);
+      routing.codex.startSession.mockClear();
+      routing.codex.respondToUserInput.mockClear();
+
+      const response = yield* Effect.result(
+        provider.respondToUserInput({
+          threadId: session.threadId,
+          requestId: asRequestId("req-user-input-stale"),
+          answers: {
+            sandbox_mode: "workspace-write",
+          },
+        }),
+      );
+
+      assertFailure(
+        response,
+        new ProviderValidationError({
+          operation: "ProviderService.respondToUserInput",
+          issue:
+            "This question belongs to a previous provider session and can no longer be answered. Ask the agent to re-ask it.",
+        }),
+      );
+      assert.equal(routing.codex.startSession.mock.calls.length, 0);
+      assert.equal(routing.codex.respondToUserInput.mock.calls.length, 0);
+    }),
+  );
+
   it.effect("recovers stale persisted sessions for rollback by resuming thread identity", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -397,8 +397,14 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const routed = yield* resolveRoutableSession({
           threadId: input.threadId,
           operation: "ProviderService.respondToUserInput",
-          allowRecovery: true,
+          allowRecovery: false,
         });
+        if (!routed.isActive) {
+          return yield* toValidationError(
+            "ProviderService.respondToUserInput",
+            "This question belongs to a previous provider session and can no longer be answered. Ask the agent to re-ask it.",
+          );
+        }
         yield* routed.adapter.respondToUserInput(routed.threadId, input.requestId, input.answers);
       });
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -106,6 +106,7 @@ import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu";
 import { cn, randomUUID } from "~/lib/utils";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import { toastManager } from "./ui/toast";
+import { logUserInputDebug } from "~/debug/userInputDebug";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
@@ -273,6 +274,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const planSidebarOpenOnNextThreadRef = useRef(false);
   const [nowTick, setNowTick] = useState(() => Date.now());
   const [terminalFocusRequestId, setTerminalFocusRequestId] = useState(0);
+  const lastPendingUserInputDebugStateRef = useRef<string | null>(null);
+  const lastThreadErrorDebugValueRef = useRef<string | null>(null);
   const [composerHighlightedItemId, setComposerHighlightedItemId] = useState<string | null>(null);
   const [pullRequestDialogState, setPullRequestDialogState] =
     useState<PullRequestDialogState | null>(null);
@@ -2516,24 +2519,47 @@ export default function ChatView({ threadId }: ChatViewProps) {
       const api = readNativeApi();
       if (!api || !activeThreadId) return;
 
+      logUserInputDebug({
+        level: "info",
+        stage: "dispatch-start",
+        message: "Dispatching thread.user-input.respond",
+        threadId: activeThreadId,
+        requestId,
+        detail: JSON.stringify(answers, null, 2),
+      });
       setRespondingUserInputRequestIds((existing) =>
         existing.includes(requestId) ? existing : [...existing, requestId],
       );
-      await api.orchestration
-        .dispatchCommand({
+      try {
+        const result = await api.orchestration.dispatchCommand({
           type: "thread.user-input.respond",
           commandId: newCommandId(),
           threadId: activeThreadId,
           requestId,
           answers,
           createdAt: new Date().toISOString(),
-        })
-        .catch((err: unknown) => {
-          setStoreThreadError(
-            activeThreadId,
-            err instanceof Error ? err.message : "Failed to submit user input.",
-          );
         });
+        logUserInputDebug({
+          level: "success",
+          stage: "dispatch-success",
+          message: "thread.user-input.respond accepted by orchestration",
+          threadId: activeThreadId,
+          requestId,
+          detail: JSON.stringify(result, null, 2),
+        });
+      } catch (err: unknown) {
+        logUserInputDebug({
+          level: "error",
+          stage: "dispatch-error",
+          message: err instanceof Error ? err.message : "Failed to submit user input.",
+          threadId: activeThreadId,
+          requestId,
+        });
+        setStoreThreadError(
+          activeThreadId,
+          err instanceof Error ? err.message : "Failed to submit user input.",
+        );
+      }
       setRespondingUserInputRequestIds((existing) => existing.filter((id) => id !== requestId));
     },
     [activeThreadId, setStoreThreadError],
@@ -2557,6 +2583,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
       if (!activePendingUserInput) {
         return;
       }
+      logUserInputDebug({
+        level: "info",
+        stage: "option-selected",
+        message: `Selected option "${optionLabel}"`,
+        threadId: activeThreadId,
+        requestId: activePendingUserInput.requestId,
+        detail: JSON.stringify({ questionId }, null, 2),
+      });
       setPendingUserInputAnswersByRequestId((existing) => ({
         ...existing,
         [activePendingUserInput.requestId]: {
@@ -2571,7 +2605,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       setComposerCursor(0);
       setComposerTrigger(null);
     },
-    [activePendingUserInput],
+    [activePendingUserInput, activeThreadId],
   );
 
   const onChangeActivePendingUserInputCustomAnswer = useCallback(
@@ -2606,22 +2640,115 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
   const onAdvanceActivePendingUserInput = useCallback(() => {
     if (!activePendingUserInput || !activePendingProgress) {
+      logUserInputDebug({
+        level: "warning",
+        stage: "advance-click",
+        message: "Advance clicked without an active pending question",
+        threadId: activeThreadId,
+      });
       return;
     }
+    logUserInputDebug({
+      level: "info",
+      stage: "advance-click",
+      message: activePendingProgress.isLastQuestion
+        ? "Submit answers clicked"
+        : "Next question clicked",
+      threadId: activeThreadId,
+      requestId: activePendingUserInput.requestId,
+      detail: JSON.stringify(
+        {
+          questionIndex: activePendingProgress.questionIndex,
+          isLastQuestion: activePendingProgress.isLastQuestion,
+          canAdvance: activePendingProgress.canAdvance,
+          hasResolvedAnswers: activePendingResolvedAnswers !== null,
+        },
+        null,
+        2,
+      ),
+    });
     if (activePendingProgress.isLastQuestion) {
       if (activePendingResolvedAnswers) {
         void onRespondToUserInput(activePendingUserInput.requestId, activePendingResolvedAnswers);
+      } else {
+        logUserInputDebug({
+          level: "warning",
+          stage: "submit-blocked",
+          message: "Submit was clicked but answers were not fully resolved",
+          threadId: activeThreadId,
+          requestId: activePendingUserInput.requestId,
+        });
       }
       return;
     }
     setActivePendingUserInputQuestionIndex(activePendingProgress.questionIndex + 1);
   }, [
+    activeThreadId,
     activePendingProgress,
     activePendingResolvedAnswers,
     activePendingUserInput,
     onRespondToUserInput,
     setActivePendingUserInputQuestionIndex,
   ]);
+
+  useEffect(() => {
+    if (!activeThreadId) {
+      lastPendingUserInputDebugStateRef.current = null;
+      return;
+    }
+    const nextState = JSON.stringify({
+      pendingCount: pendingUserInputs.length,
+      activeRequestId: activePendingUserInput?.requestId ?? null,
+      questionIndex: activePendingQuestionIndex,
+      isResponding: activePendingIsResponding,
+      isLastQuestion: activePendingProgress?.isLastQuestion ?? null,
+      canAdvance: activePendingProgress?.canAdvance ?? null,
+      isComplete: activePendingProgress?.isComplete ?? null,
+      answeredQuestionCount: activePendingProgress?.answeredQuestionCount ?? null,
+      hasResolvedAnswers: activePendingResolvedAnswers !== null,
+    });
+    if (lastPendingUserInputDebugStateRef.current === nextState) {
+      return;
+    }
+    lastPendingUserInputDebugStateRef.current = nextState;
+    logUserInputDebug({
+      level: "info",
+      stage: "pending-state",
+      message: "Pending user input state changed",
+      threadId: activeThreadId,
+      requestId: activePendingUserInput?.requestId ?? null,
+      detail: nextState,
+    });
+  }, [
+    activePendingIsResponding,
+    activePendingProgress?.answeredQuestionCount,
+    activePendingProgress?.canAdvance,
+    activePendingProgress?.isComplete,
+    activePendingProgress?.isLastQuestion,
+    activePendingQuestionIndex,
+    activePendingResolvedAnswers,
+    activePendingUserInput?.requestId,
+    activeThreadId,
+    pendingUserInputs.length,
+  ]);
+
+  useEffect(() => {
+    const nextError = activeThread?.error ?? null;
+    if (lastThreadErrorDebugValueRef.current === nextError) {
+      return;
+    }
+    lastThreadErrorDebugValueRef.current = nextError;
+    if (!nextError) {
+      return;
+    }
+    logUserInputDebug({
+      level: "error",
+      stage: "thread-error",
+      message: nextError,
+      threadId: activeThread?.id ?? activeThreadId,
+      requestId: activePendingUserInput?.requestId ?? null,
+    });
+  }, [activePendingUserInput?.requestId, activeThread?.error, activeThread?.id, activeThreadId]);
 
   const onPreviousActivePendingUserInputQuestion = useCallback(() => {
     if (!activePendingProgress) {
@@ -3636,9 +3763,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
                             </Button>
                           ) : null}
                           <Button
-                            type="submit"
+                            type="button"
                             size="sm"
                             className="rounded-full px-4"
+                            onClick={onAdvanceActivePendingUserInput}
                             disabled={
                               activePendingIsResponding ||
                               (activePendingProgress.isLastQuestion

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -73,6 +73,13 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   const selectOptionAndAutoAdvance = useCallback(
     (questionId: string, optionLabel: string) => {
       onSelectOption(questionId, optionLabel);
+      if (progress.isLastQuestion) {
+        if (autoAdvanceTimerRef.current !== null) {
+          window.clearTimeout(autoAdvanceTimerRef.current);
+          autoAdvanceTimerRef.current = null;
+        }
+        return;
+      }
       if (autoAdvanceTimerRef.current !== null) {
         window.clearTimeout(autoAdvanceTimerRef.current);
       }
@@ -81,7 +88,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
         onAdvance();
       }, 200);
     },
-    [onSelectOption, onAdvance],
+    [onSelectOption, onAdvance, progress.isLastQuestion],
   );
 
   // Keyboard shortcut: number keys 1-9 select corresponding option and auto-advance.

--- a/apps/web/src/components/debug/UserInputDebugPanel.tsx
+++ b/apps/web/src/components/debug/UserInputDebugPanel.tsx
@@ -1,0 +1,317 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } from "react";
+
+import {
+  clearUserInputDebugEntries,
+  setUserInputDebugCollapsed,
+  setUserInputDebugEnabled,
+  setUserInputDebugPosition,
+  useUserInputDebugStore,
+} from "~/debug/userInputDebug";
+import { Button } from "../ui/button";
+import { cn } from "~/lib/utils";
+
+function toneClass(level: "info" | "success" | "warning" | "error"): string {
+  switch (level) {
+    case "success":
+      return "border-emerald-500/25 bg-emerald-500/10 text-emerald-100";
+    case "warning":
+      return "border-amber-500/25 bg-amber-500/10 text-amber-100";
+    case "error":
+      return "border-rose-500/25 bg-rose-500/10 text-rose-100";
+    default:
+      return "border-white/10 bg-white/6 text-white/90";
+  }
+}
+
+function formatDetail(detail: string | undefined): string | null {
+  if (!detail) {
+    return null;
+  }
+  const trimmed = detail.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function UserInputDebugPanel() {
+  const enabled = useUserInputDebugStore((store) => store.enabled);
+  const collapsed = useUserInputDebugStore((store) => store.collapsed);
+  const position = useUserInputDebugStore((store) => store.position);
+  const entries = useUserInputDebugStore((store) => store.entries);
+  const [copied, setCopied] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dragStateRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+    width: number;
+    height: number;
+    moved: boolean;
+  } | null>(null);
+  const suppressClickRef = useRef(false);
+
+  const copyEntries = useCallback(async () => {
+    const text = entries
+      .map((entry) =>
+        [
+          entry.timestamp,
+          entry.level.toUpperCase(),
+          entry.stage,
+          entry.message,
+          entry.threadId ? `thread=${entry.threadId}` : null,
+          entry.requestId ? `request=${entry.requestId}` : null,
+          entry.detail ? `detail=${entry.detail}` : null,
+        ]
+          .filter(Boolean)
+          .join(" | "),
+      )
+      .join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  }, [entries]);
+
+  const renderedEntries = useMemo(() => entries.toReversed(), [entries]);
+
+  const updatePosition = useCallback(
+    (nextX: number, nextY: number, width: number, height: number) => {
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const margin = 8;
+      const clampedX = Math.min(
+        Math.max(margin, nextX),
+        Math.max(margin, viewportWidth - width - margin),
+      );
+      const clampedY = Math.min(
+        Math.max(margin, nextY),
+        Math.max(margin, viewportHeight - height - margin),
+      );
+      setUserInputDebugPosition({ x: clampedX, y: clampedY });
+    },
+    [],
+  );
+
+  const beginDrag = useCallback((event: PointerEvent<HTMLElement>) => {
+    if (event.button !== 0) {
+      return;
+    }
+    const element = containerRef.current;
+    if (!element) {
+      return;
+    }
+    const rect = element.getBoundingClientRect();
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: rect.left,
+      originY: rect.top,
+      width: rect.width,
+      height: rect.height,
+      moved: false,
+    };
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }, []);
+
+  const onDragMove = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      const dragState = dragStateRef.current;
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+      const deltaX = event.clientX - dragState.startX;
+      const deltaY = event.clientY - dragState.startY;
+      if (!dragState.moved && Math.abs(deltaX) + Math.abs(deltaY) > 6) {
+        dragState.moved = true;
+      }
+      updatePosition(
+        dragState.originX + deltaX,
+        dragState.originY + deltaY,
+        dragState.width,
+        dragState.height,
+      );
+      event.preventDefault();
+    },
+    [updatePosition],
+  );
+
+  const endDrag = useCallback((event: PointerEvent<HTMLElement>) => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return;
+    }
+    dragStateRef.current = null;
+    suppressClickRef.current = dragState.moved;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    window.setTimeout(() => {
+      suppressClickRef.current = false;
+    }, 0);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !position) {
+      return;
+    }
+    const onResize = () => {
+      const element = containerRef.current;
+      if (!element) {
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      updatePosition(position.x, position.y, rect.width, rect.height);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [enabled, position, updatePosition]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  const floatingStyle =
+    position === null
+      ? undefined
+      : {
+          left: `${position.x}px`,
+          top: `${position.y}px`,
+          right: "auto",
+          bottom: "auto",
+        };
+
+  const actionButtonClass =
+    "border-white/20 bg-white/12 text-white hover:bg-white/22 hover:text-white";
+
+  if (collapsed) {
+    return (
+      <div ref={containerRef} className="fixed bottom-3 right-3 z-50" style={floatingStyle}>
+        <button
+          type="button"
+          className="rounded-full border border-white/15 bg-neutral-950/92 px-4 py-2 text-sm font-medium text-white shadow-2xl backdrop-blur-md"
+          onPointerDown={beginDrag}
+          onPointerMove={onDragMove}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+          onClick={() => {
+            if (suppressClickRef.current) {
+              return;
+            }
+            setUserInputDebugCollapsed(false);
+          }}
+        >
+          Open Debug
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <aside
+      ref={containerRef}
+      className="fixed inset-x-2 bottom-2 z-50 max-h-[45vh] overflow-hidden rounded-2xl border border-white/12 bg-neutral-950/92 text-white shadow-2xl backdrop-blur-md sm:right-4 sm:w-[28rem] sm:inset-x-auto"
+      style={floatingStyle}
+    >
+      <div
+        className="flex cursor-grab touch-none items-center justify-between gap-2 border-b border-white/10 px-3 py-2 active:cursor-grabbing"
+        onPointerDown={beginDrag}
+        onPointerMove={onDragMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      >
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold tracking-[0.16em] text-white/55 uppercase">
+            User Input Debug
+          </p>
+          <p className="truncate text-xs text-white/70">
+            Mobile-visible breadcrumbs for pending question submit flow
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            size="xs"
+            variant="outline"
+            className={actionButtonClass}
+            onClick={() => clearUserInputDebugEntries()}
+          >
+            Clear
+          </Button>
+          <Button
+            size="xs"
+            variant="outline"
+            className={actionButtonClass}
+            onClick={() => void copyEntries()}
+          >
+            {copied ? "Copied" : "Copy"}
+          </Button>
+          <Button
+            size="xs"
+            variant="outline"
+            className={actionButtonClass}
+            onClick={() => setUserInputDebugCollapsed(true)}
+          >
+            Collapse
+          </Button>
+          <Button
+            size="xs"
+            variant="outline"
+            className={actionButtonClass}
+            onClick={() => setUserInputDebugEnabled(false)}
+          >
+            Off
+          </Button>
+        </div>
+      </div>
+      <div className="max-h-[calc(45vh-3rem)] space-y-2 overflow-y-auto px-3 py-3">
+        {renderedEntries.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-white/12 px-3 py-4 text-sm text-white/55">
+            Waiting for breadcrumbs...
+          </div>
+        ) : (
+          renderedEntries.map((entry) => {
+            const detail = formatDetail(entry.detail);
+            return (
+              <section
+                key={entry.id}
+                className={cn("rounded-xl border px-3 py-2", toneClass(entry.level))}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-[11px] font-semibold tracking-[0.14em] uppercase">
+                      {entry.stage}
+                    </p>
+                    <p className="mt-1 text-sm leading-snug">{entry.message}</p>
+                  </div>
+                  <time className="shrink-0 text-[10px] text-white/45">
+                    {new Date(entry.timestamp).toLocaleTimeString([], {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                      second: "2-digit",
+                    })}
+                  </time>
+                </div>
+                {entry.threadId || entry.requestId ? (
+                  <p className="mt-2 text-[11px] text-white/55">
+                    {entry.threadId ? `thread=${entry.threadId}` : null}
+                    {entry.threadId && entry.requestId ? " " : null}
+                    {entry.requestId ? `request=${entry.requestId}` : null}
+                  </p>
+                ) : null}
+                {detail ? (
+                  <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words rounded-lg bg-black/20 px-2 py-1.5 text-[11px] leading-relaxed text-white/72">
+                    {detail}
+                  </pre>
+                ) : null}
+              </section>
+            );
+          })
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/debug/userInputDebug.ts
+++ b/apps/web/src/debug/userInputDebug.ts
@@ -1,0 +1,225 @@
+import { create } from "zustand";
+
+const USER_INPUT_DEBUG_QUERY_PARAM = "debugUserInput";
+const USER_INPUT_DEBUG_STORAGE_KEY = "t3code:debug-user-input";
+const MAX_DEBUG_ENTRIES = 200;
+
+type UserInputDebugLevel = "info" | "success" | "warning" | "error";
+
+export interface UserInputDebugEntry {
+  id: string;
+  timestamp: string;
+  level: UserInputDebugLevel;
+  stage: string;
+  message: string;
+  threadId?: string | null;
+  requestId?: string | null;
+  detail?: string;
+}
+
+interface UserInputDebugState {
+  enabled: boolean;
+  collapsed: boolean;
+  position: { x: number; y: number } | null;
+  entries: UserInputDebugEntry[];
+  setEnabled: (enabled: boolean) => void;
+  setCollapsed: (collapsed: boolean) => void;
+  setPosition: (position: { x: number; y: number } | null) => void;
+  pushEntry: (entry: Omit<UserInputDebugEntry, "id" | "timestamp">) => void;
+  clear: () => void;
+}
+
+function readSearchParamEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const value = new URLSearchParams(window.location.search).get(USER_INPUT_DEBUG_QUERY_PARAM);
+  return value === "1" || value === "true" || value === "on";
+}
+
+function readPersistedEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    const raw = window.localStorage.getItem(USER_INPUT_DEBUG_STORAGE_KEY);
+    if (!raw) {
+      return false;
+    }
+    if (raw === "1") {
+      return true;
+    }
+    const parsed = JSON.parse(raw) as { enabled?: boolean };
+    return parsed.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+function readPersistedLayout(): {
+  collapsed: boolean;
+  position: { x: number; y: number } | null;
+} {
+  if (typeof window === "undefined") {
+    return { collapsed: false, position: null };
+  }
+  try {
+    const raw = window.localStorage.getItem(USER_INPUT_DEBUG_STORAGE_KEY);
+    if (!raw || raw === "1") {
+      return { collapsed: false, position: null };
+    }
+    const parsed = JSON.parse(raw) as {
+      collapsed?: boolean;
+      position?: { x?: number; y?: number } | null;
+    };
+    return {
+      collapsed: parsed.collapsed === true,
+      position:
+        parsed.position &&
+        typeof parsed.position.x === "number" &&
+        typeof parsed.position.y === "number"
+          ? { x: parsed.position.x, y: parsed.position.y }
+          : null,
+    };
+  } catch {
+    return { collapsed: false, position: null };
+  }
+}
+
+function persistDebugState(input: {
+  enabled: boolean;
+  collapsed: boolean;
+  position: { x: number; y: number } | null;
+}): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    if (input.enabled) {
+      window.localStorage.setItem(
+        USER_INPUT_DEBUG_STORAGE_KEY,
+        JSON.stringify({
+          enabled: true,
+          collapsed: input.collapsed,
+          position: input.position,
+        }),
+      );
+      return;
+    }
+    window.localStorage.removeItem(USER_INPUT_DEBUG_STORAGE_KEY);
+  } catch {
+    // Ignore storage write failures in debug mode.
+  }
+}
+
+function resolveInitialEnabled(): boolean {
+  const enabled = readSearchParamEnabled() || readPersistedEnabled();
+  if (enabled) {
+    const layout = readPersistedLayout();
+    persistDebugState({
+      enabled: true,
+      collapsed: layout.collapsed,
+      position: layout.position,
+    });
+  }
+  return enabled;
+}
+
+function nextDebugId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `user-input-debug-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+const initialEnabled = resolveInitialEnabled();
+const initialLayout = readPersistedLayout();
+
+export const useUserInputDebugStore = create<UserInputDebugState>((set) => ({
+  enabled: initialEnabled,
+  collapsed: initialLayout.collapsed,
+  position: initialLayout.position,
+  entries: [],
+  setEnabled: (enabled) => {
+    set((state) => {
+      persistDebugState({
+        enabled,
+        collapsed: enabled ? state.collapsed : false,
+        position: enabled ? state.position : null,
+      });
+      return {
+        enabled,
+        collapsed: enabled ? state.collapsed : false,
+        position: enabled ? state.position : null,
+      };
+    });
+  },
+  setCollapsed: (collapsed) => {
+    set((state) => {
+      persistDebugState({
+        enabled: state.enabled,
+        collapsed,
+        position: state.position,
+      });
+      return { collapsed };
+    });
+  },
+  setPosition: (position) => {
+    set((state) => {
+      persistDebugState({
+        enabled: state.enabled,
+        collapsed: state.collapsed,
+        position,
+      });
+      return { position };
+    });
+  },
+  pushEntry: (entry) =>
+    set((state) => {
+      if (!state.enabled) {
+        return state;
+      }
+      const nextEntry: UserInputDebugEntry = {
+        ...entry,
+        id: nextDebugId(),
+        timestamp: new Date().toISOString(),
+      };
+      const nextEntries = [...state.entries, nextEntry];
+      return {
+        entries:
+          nextEntries.length > MAX_DEBUG_ENTRIES
+            ? nextEntries.slice(nextEntries.length - MAX_DEBUG_ENTRIES)
+            : nextEntries,
+      };
+    }),
+  clear: () => set({ entries: [] }),
+}));
+
+export function logUserInputDebug(entry: Omit<UserInputDebugEntry, "id" | "timestamp">): void {
+  const store = useUserInputDebugStore.getState();
+  if (!store.enabled) {
+    return;
+  }
+  store.pushEntry(entry);
+  console.debug("[user-input-debug]", entry);
+}
+
+export function setUserInputDebugEnabled(enabled: boolean): void {
+  useUserInputDebugStore.getState().setEnabled(enabled);
+}
+
+export function setUserInputDebugCollapsed(collapsed: boolean): void {
+  useUserInputDebugStore.getState().setCollapsed(collapsed);
+}
+
+export function setUserInputDebugPosition(position: { x: number; y: number } | null): void {
+  useUserInputDebugStore.getState().setPosition(position);
+}
+
+export function clearUserInputDebugEntries(): void {
+  useUserInputDebugStore.getState().clear();
+}
+
+export function isUserInputDebugEnabled(): boolean {
+  return useUserInputDebugStore.getState().enabled;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { ThreadId } from "@t3tools/contracts";
+import { ThreadId, type OrchestrationThreadActivity } from "@t3tools/contracts";
 import {
   Outlet,
   createRootRouteWithContext,
@@ -13,6 +13,8 @@ import { Throttler } from "@tanstack/react-pacer";
 import { APP_DISPLAY_NAME } from "../branding";
 import { Button } from "../components/ui/button";
 import { AnchoredToastProvider, ToastProvider, toastManager } from "../components/ui/toast";
+import { UserInputDebugPanel } from "../components/debug/UserInputDebugPanel";
+import { logUserInputDebug } from "../debug/userInputDebug";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { serverConfigQueryOptions, serverQueryKeys } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
@@ -53,6 +55,7 @@ function RootRouteView() {
       <AnchoredToastProvider>
         <EventRouter />
         <DesktopProjectBootstrap />
+        <UserInputDebugPanel />
         <Outlet />
       </AnchoredToastProvider>
     </ToastProvider>
@@ -207,6 +210,41 @@ function EventRouter() {
     );
 
     const unsubDomainEvent = api.orchestration.onDomainEvent((event) => {
+      if (event.type === "thread.user-input-response-requested") {
+        logUserInputDebug({
+          level: "info",
+          stage: "domain-event",
+          message: "Observed thread.user-input-response-requested",
+          threadId: event.payload.threadId,
+          requestId: event.payload.requestId,
+          ...withDebugDetail(stringifyDebugDetail(event.payload.answers)),
+        });
+      }
+      if (event.type === "thread.activity-appended") {
+        const activity = event.payload.activity;
+        if (isInterestingUserInputActivity(activity)) {
+          logUserInputDebug({
+            level: activity.kind === "provider.user-input.respond.failed" ? "error" : "success",
+            stage: "domain-activity",
+            message: `Observed ${activity.kind}`,
+            threadId: event.payload.threadId,
+            requestId: requestIdFromActivity(activity),
+            ...withDebugDetail(
+              stringifyDebugDetail({
+                summary: activity.summary,
+                payload: activity.payload,
+              }),
+            ),
+          });
+        }
+        if (activity.kind === "provider.user-input.respond.failed") {
+          toastManager.add({
+            type: "error",
+            title: "Question expired",
+            description: describePendingUserInputFailure(activity),
+          });
+        }
+      }
       if (event.sequence <= latestSequence) {
         return;
       }
@@ -319,6 +357,61 @@ function EventRouter() {
   ]);
 
   return null;
+}
+
+function isInterestingUserInputActivity(activity: OrchestrationThreadActivity): boolean {
+  return (
+    activity.kind === "user-input.requested" ||
+    activity.kind === "user-input.resolved" ||
+    activity.kind === "provider.user-input.respond.failed"
+  );
+}
+
+function requestIdFromActivity(activity: OrchestrationThreadActivity): string | null {
+  const payload = activity.payload;
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const requestId = (payload as Record<string, unknown>).requestId;
+  return typeof requestId === "string" ? requestId : null;
+}
+
+function stringifyDebugDetail(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function withDebugDetail(detail: string | undefined): { detail: string } | undefined {
+  return typeof detail === "string" ? { detail } : undefined;
+}
+
+function describePendingUserInputFailure(activity: OrchestrationThreadActivity): string {
+  const payload =
+    activity.payload && typeof activity.payload === "object"
+      ? (activity.payload as Record<string, unknown>)
+      : null;
+  const detail = typeof payload?.detail === "string" ? payload.detail : null;
+  if (!detail) {
+    return "This question could not be answered.";
+  }
+  const normalized = detail.toLowerCase();
+  if (
+    normalized.includes("unknown pending user input request") ||
+    normalized.includes("belongs to a previous provider session") ||
+    normalized.includes("expired after the session restarted")
+  ) {
+    return (
+      "This question came from an earlier session and can no longer be answered. " +
+      "Ask the agent to re-ask it."
+    );
+  }
+  return detail;
 }
 
 function DesktopProjectBootstrap() {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -220,6 +220,48 @@ describe("derivePendingUserInputs", () => {
       },
     ]);
   });
+
+  it("clears stale pending user input when the provider reports an expired request", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-open-stale",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-stale",
+          questions: [
+            {
+              id: "sandbox_mode",
+              header: "Sandbox",
+              question: "Which mode should be used?",
+              options: [
+                {
+                  label: "workspace-write",
+                  description: "Allow workspace writes only",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      makeActivity({
+        id: "user-input-stale-failed",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "provider.user-input.respond.failed",
+        summary: "Provider user input response failed",
+        tone: "error",
+        payload: {
+          requestId: "req-user-input-stale",
+          detail:
+            "This question came from an earlier provider session and expired after the session restarted. Please ask the agent to re-ask the question.",
+        },
+      }),
+    ];
+
+    expect(derivePendingUserInputs(activities)).toEqual([]);
+  });
 });
 
 describe("deriveActivePlanState", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -156,6 +156,18 @@ function requestKindFromRequestType(requestType: unknown): PendingApproval["requ
   }
 }
 
+function isStalePendingUserInputDetail(detail: string | undefined): boolean {
+  if (!detail) {
+    return false;
+  }
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("unknown pending user input request") ||
+    normalized.includes("belongs to a previous provider session") ||
+    normalized.includes("expired after the session restarted")
+  );
+}
+
 export function derivePendingApprovals(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingApproval[] {
@@ -291,6 +303,16 @@ export function derivePendingUserInputs(
     }
 
     if (activity.kind === "user-input.resolved" && requestId) {
+      openByRequestId.delete(requestId);
+      continue;
+    }
+
+    const detail = payload && typeof payload.detail === "string" ? payload.detail : undefined;
+    if (
+      activity.kind === "provider.user-input.respond.failed" &&
+      requestId &&
+      isStalePendingUserInputDetail(detail)
+    ) {
       openByRequestId.delete(requestId);
     }
   }


### PR DESCRIPTION
## Summary

This promotes the pending-question work we validated on dev.

- add a mobile-visible user-input debug panel for tracing pending question flow
- stop recovering provider sessions when responding to pending user input
- fail fast with a clear stale-question message after session restart
- clear stale pending question UI on the web so normal chat becomes usable again
- document the Bun PATH/Turbo typecheck gotcha in `AGENTS.md`

## Root Cause

Pending user-input request IDs are session-local and live only in the original provider session's in-memory request map. After a service restart, the thread can still show the pending question in persisted activity state, but the original request ID is no longer answerable.

Before this change, `respondToUserInput` allowed provider-session recovery, which made the server attempt to answer a stale request on a different session. That produced `Unknown pending user input request` and left the thread stuck on the question UI.

## Fix

- set `allowRecovery: false` for `respondToUserInput`
- return a clear stale-session validation error instead of attempting recovery
- map stale user-input failures to a user-facing recovery message in orchestration
- treat stale user-input failures as closed prompts in session derivation
- show a `Question expired` toast and restore access to normal chat

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- targeted Vitest coverage for provider service, provider command reactor, and web session logic

## Related

- https://github.com/mcorrig4/t3code/issues/1
- https://github.com/mcorrig4/t3code/issues/2
- https://github.com/pingdotgg/t3code/issues/469
- https://github.com/pingdotgg/t3code/issues/503
- https://github.com/pingdotgg/t3code/issues/856
- https://github.com/pingdotgg/t3code/pull/862
