### PR TITLE
Phase 3: restore mobile UI polish and native TTS

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1624,7 +1624,7 @@ function ComposerPromptEditorInner({
           contentEditable={
             <ContentEditable
               className={cn(
-                "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-[14px] leading-relaxed text-foreground focus:outline-none",
+                "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-base leading-relaxed text-foreground focus:outline-none sm:text-[14px]",
                 className,
               )}
               data-testid="composer-editor"
@@ -1635,7 +1635,7 @@ function ComposerPromptEditorInner({
           }
           placeholder={
             terminalContexts.length > 0 ? null : (
-              <div className="pointer-events-none absolute inset-0 text-[14px] leading-relaxed text-muted-foreground/35">
+              <div className="pointer-events-none absolute inset-0 text-base leading-relaxed text-muted-foreground/35 sm:text-[14px]">
                 {placeholder}
               </div>
             )

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -502,7 +502,12 @@ describe("resolveThreadStatusPill", () => {
           hasPendingUserInput: true,
         },
       }),
-    ).toMatchObject({ label: "Awaiting Input", pulse: false });
+    ).toMatchObject({
+      label: "Awaiting Input",
+      colorClass: "text-red-600 dark:text-red-300/90",
+      dotClass: "bg-red-500 dark:bg-red-300/90",
+      pulse: false,
+    });
   });
 
   it("falls back to working when the thread is actively running without blockers", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -343,8 +343,8 @@ export function resolveThreadStatusPill(input: {
   if (thread.hasPendingUserInput) {
     return {
       label: "Awaiting Input",
-      colorClass: "text-indigo-600 dark:text-indigo-300/90",
-      dotClass: "bg-indigo-500 dark:bg-indigo-300/90",
+      colorClass: "text-red-600 dark:text-red-300/90",
+      dotClass: "bg-red-500 dark:bg-red-300/90",
       pulse: false,
     };
   }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -162,6 +162,7 @@ import {
   ThreadStatusPill,
 } from "./Sidebar.logic";
 import { sortThreads } from "../lib/threadSort";
+import ForkThreadContextMenuButton from "./sidebar/ForkThreadContextMenuButton";
 import { SidebarUpdatePill } from "./sidebar/SidebarUpdatePill";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { CommandDialogTrigger } from "./ui/command";
@@ -541,7 +542,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
         className={`${resolveThreadRowClassName({
           isActive,
           isSelected,
-        })} relative isolate`}
+        })} group/thread-row relative isolate`}
         onClick={handleRowClick}
         onKeyDown={handleRowKeyDown}
         onContextMenu={handleRowContextMenu}
@@ -567,6 +568,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
           {threadStatus && <ThreadStatusLabel status={threadStatus} />}
           {renamingThreadKey === threadKey ? (
             <input
+              data-slot="thread-rename-input"
               ref={handleRenameInputRef}
               className="min-w-0 flex-1 truncate text-xs bg-transparent outline-none border border-ring rounded px-0.5"
               value={renamingTitle}
@@ -695,6 +697,13 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
                 )}
               </span>
             </span>
+            <ForkThreadContextMenuButton
+              threadTitle={thread.title}
+              isHighlighted={isHighlighted}
+              onOpenFromAnchor={(position) => {
+                void handleThreadContextMenu(threadRef, position);
+              }}
+            />
           </div>
         </div>
       </SidebarMenuSubButton>
@@ -794,6 +803,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
     <SidebarMenuSub
       ref={attachThreadListAutoAnimateRef}
       className="mx-1 my-0 w-full translate-x-0 gap-0.5 overflow-hidden px-1.5 py-0"
+      data-project-threads
     >
       {shouldShowThreadPanel && showEmptyThreadState ? (
         <SidebarMenuSubItem className="w-full" data-thread-selection-safe>
@@ -1945,13 +1955,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 
   return (
     <>
-      <div className="group/project-header relative">
+      <div className="group/project-header relative" data-project-header>
         <SidebarMenuButton
           ref={isManualProjectSorting ? dragHandleProps?.setActivatorNodeRef : undefined}
           size="sm"
           className={`gap-2 px-2 py-1.5 text-left hover:bg-accent group-hover/project-header:bg-accent group-hover/project-header:text-sidebar-accent-foreground ${
             isManualProjectSorting ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"
           }`}
+          data-project-row
           {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.attributes : {})}
           {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.listeners : {})}
           onPointerDownCapture={handleProjectButtonPointerDownCapture}
@@ -2007,6 +2018,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                       : "Available in multiple environments"
                   }
                   className="pointer-events-none absolute top-1 right-1.5 inline-flex size-5 items-center justify-center rounded-md text-muted-foreground/50 transition-opacity duration-150 group-hover/project-header:opacity-0 group-focus-within/project-header:opacity-0"
+                  data-project-status
                 />
               }
             >
@@ -2020,7 +2032,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         <Tooltip>
           <TooltipTrigger
             render={
-              <div className="pointer-events-none absolute top-1 right-1.5 opacity-0 transition-opacity duration-150 group-hover/project-header:pointer-events-auto group-hover/project-header:opacity-100 group-focus-within/project-header:pointer-events-auto group-focus-within/project-header:opacity-100">
+              <div
+                className="pointer-events-none absolute top-1 right-1.5 opacity-0 transition-opacity duration-150 group-hover/project-header:pointer-events-auto group-hover/project-header:opacity-100 group-focus-within/project-header:pointer-events-auto group-focus-within/project-header:opacity-100"
+                data-project-action
+              >
                 <button
                   type="button"
                   aria-label={`Create new thread in ${project.displayName}`}
@@ -2569,7 +2584,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
         </SidebarGroup>
       ) : null}
       <SidebarGroup className="px-2 py-2">
-        <div className="mb-1 flex items-center justify-between pl-2 pr-1.5">
+        <div className="mb-1 flex items-center justify-between pl-2 pr-1.5" data-projects-heading>
           <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
             Projects
           </span>
@@ -2610,7 +2625,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
             onDragEnd={handleProjectDragEnd}
             onDragCancel={handleProjectDragCancel}
           >
-            <SidebarMenu>
+            <SidebarMenu data-projects-list>
               <SortableContext
                 items={sortedProjects.map((project) => project.projectKey)}
                 strategy={verticalListSortingStrategy}
@@ -2647,7 +2662,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
             </SidebarMenu>
           </DndContext>
         ) : (
-          <SidebarMenu ref={attachProjectListAutoAnimateRef}>
+          <SidebarMenu ref={attachProjectListAutoAnimateRef} data-projects-list>
             {sortedProjects.map((project) => (
               <SidebarProjectListRow
                 key={project.projectKey}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1,7 +1,7 @@
 import { EnvironmentId, MessageId } from "@t3tools/contracts";
 import { createRef } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LegendListRef } from "@legendapp/list/react";
 
 vi.mock("@legendapp/list/react", async () => {
@@ -63,6 +63,9 @@ beforeAll(() => {
     },
     cancelAnimationFrame: () => {},
     desktopBridge: undefined,
+    location: {
+      hostname: "localhost",
+    },
   });
   vi.stubGlobal("document", {
     documentElement: {
@@ -70,6 +73,11 @@ beforeAll(() => {
       offsetHeight: 0,
     },
   });
+});
+
+beforeEach(() => {
+  Reflect.deleteProperty(globalThis, "speechSynthesis");
+  Reflect.deleteProperty(globalThis, "SpeechSynthesisUtterance");
 });
 
 const ACTIVE_THREAD_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
@@ -185,5 +193,83 @@ describe("MessagesTimeline", () => {
 
     expect(markup).toContain("t3code/apps/web/src/session-logic.ts");
     expect(markup).not.toContain("C:/Users/mike/dev-stuff/t3code/apps/web/src/session-logic.ts");
+  });
+
+  it("renders native TTS controls and touch-visible action hooks for completed assistant messages", async () => {
+    vi.stubGlobal("speechSynthesis", {
+      cancel: () => {},
+      getVoices: () => [],
+      speak: () => {},
+    } satisfies Partial<SpeechSynthesis>);
+    vi.stubGlobal(
+      "SpeechSynthesisUtterance",
+      class MockSpeechSynthesisUtterance {
+        readonly text: string;
+        lang = "";
+        rate = 1;
+        voice: SpeechSynthesisVoice | null = null;
+
+        constructor(text: string) {
+          this.text = text;
+        }
+      } as unknown as typeof SpeechSynthesisUtterance,
+    );
+
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "assistant-entry",
+            kind: "message",
+            createdAt: "2026-04-13T12:00:10.000Z",
+            message: {
+              id: MessageId.make("assistant-1"),
+              role: "assistant",
+              text: "Read this response aloud.",
+              turnId: null,
+              createdAt: "2026-04-13T12:00:10.000Z",
+              completedAt: "2026-04-13T12:00:12.000Z",
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('data-slot="assistant-message-tts"');
+    expect(markup).toContain("Play message");
+    expect(markup).toContain('data-slot="assistant-message-actions"');
+    expect(markup).toContain("pointer-coarse:opacity-100");
+  });
+
+  it("renders touch-visible user message actions when copy or revert is available", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        revertTurnCountByUserMessageId={new Map([[MessageId.make("user-1"), 1]])}
+        timelineEntries={[
+          {
+            id: "user-entry",
+            kind: "message",
+            createdAt: "2026-04-13T12:00:10.000Z",
+            message: {
+              id: MessageId.make("user-1"),
+              role: "user",
+              text: "Please undo that change.",
+              turnId: null,
+              createdAt: "2026-04-13T12:00:10.000Z",
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('data-slot="user-message-actions"');
+    expect(markup).toContain("pointer-coarse:opacity-100");
+    expect(markup).toContain("Revert to this message");
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -35,6 +35,7 @@ import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesTree } from "./ChangedFilesTree";
 import { DiffStatLabel, hasNonZeroStat } from "./DiffStatLabel";
 import { MessageCopyButton } from "./MessageCopyButton";
+import { AssistantMessageTtsButton } from "~/features/tts/AssistantMessageTtsButton";
 import {
   computeStableMessagesTimelineRows,
   MAX_VISIBLE_WORK_LOG_ENTRIES,
@@ -61,6 +62,12 @@ import {
   textContainsInlineTerminalContextLabels,
 } from "./userMessageTerminalContexts";
 import { formatWorkspaceRelativePath } from "../../filePathDisplay";
+
+const TOUCH_VISIBLE_MESSAGE_ACTIONS_CLASS =
+  "pointer-coarse:opacity-100 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100";
+
+const TOUCH_VISIBLE_ASSISTANT_ACTIONS_CLASS =
+  "pointer-coarse:opacity-100 opacity-0 transition-opacity duration-200 group-hover/assistant:opacity-100";
 
 // ---------------------------------------------------------------------------
 // Context — shared state consumed by every row component via useContext.
@@ -350,7 +357,10 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
                   />
                 )}
                 <div className="mt-1.5 flex items-center justify-end gap-2">
-                  <div className="flex items-center gap-1.5 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+                  <div
+                    className={cn("flex items-center gap-1.5", TOUCH_VISIBLE_MESSAGE_ACTIONS_CLASS)}
+                    data-slot="user-message-actions"
+                  >
                     {displayedUserMessage.copyText && (
                       <MessageCopyButton text={displayedUserMessage.copyText} />
                     )}
@@ -413,8 +423,14 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
                   resolvedTheme={ctx.resolvedTheme}
                   onOpenTurnDiff={ctx.onOpenTurnDiff}
                 />
-                <div className="mt-1.5 flex items-center gap-2">
-                  <p className="text-[10px] text-muted-foreground/30">
+                <div
+                  className="mt-1.5 flex flex-wrap items-center gap-2 text-[10px] text-muted-foreground/30"
+                  data-assistant-message-meta
+                >
+                  {!row.message.streaming && row.message.text.trim().length > 0 ? (
+                    <AssistantMessageTtsButton messageId={row.message.id} text={row.message.text} />
+                  ) : null}
+                  <p data-assistant-message-timestamp>
                     {row.message.streaming ? (
                       <LiveMessageMeta
                         createdAt={row.message.createdAt}
@@ -430,7 +446,10 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
                     )}
                   </p>
                   {assistantCopyState.visible ? (
-                    <div className="flex items-center opacity-0 transition-opacity duration-200  group-hover/assistant:opacity-100">
+                    <div
+                      className={cn("flex items-center", TOUCH_VISIBLE_ASSISTANT_ACTIONS_CLASS)}
+                      data-slot="assistant-message-actions"
+                    >
                       <MessageCopyButton
                         text={assistantCopyState.text ?? ""}
                         size="icon-xs"

--- a/apps/web/src/components/sidebar/ForkThreadContextMenuButton.test.tsx
+++ b/apps/web/src/components/sidebar/ForkThreadContextMenuButton.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import ForkThreadContextMenuButton, {
+  openThreadContextMenuFromButton,
+  stopThreadContextMenuButtonPointerDown,
+} from "./ForkThreadContextMenuButton";
+
+describe("ForkThreadContextMenuButton", () => {
+  it("renders a button with the expected aria-label", () => {
+    const html = renderToStaticMarkup(
+      <ForkThreadContextMenuButton
+        threadTitle="Debug flaky sync"
+        isHighlighted={false}
+        onOpenFromAnchor={() => {}}
+      />,
+    );
+
+    expect(html).toContain('aria-label="Open thread actions for Debug flaky sync"');
+    expect(html).toContain('data-slot="fork-thread-context-menu-button"');
+  });
+
+  it("calls onOpenFromAnchor on click with a lower-right button anchor", () => {
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    const onOpenFromAnchor = vi.fn();
+
+    openThreadContextMenuFromButton(
+      {
+        preventDefault,
+        stopPropagation,
+        currentTarget: {
+          getBoundingClientRect: () => ({
+            right: 36,
+            bottom: 44,
+          }),
+        },
+      },
+      onOpenFromAnchor,
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(onOpenFromAnchor).toHaveBeenCalledWith({ x: 36, y: 48 });
+  });
+
+  it("stops propagation on pointer down so parent row handlers do not run", () => {
+    const stopPropagation = vi.fn();
+
+    stopThreadContextMenuButtonPointerDown({ stopPropagation });
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/sidebar/ForkThreadContextMenuButton.tsx
+++ b/apps/web/src/components/sidebar/ForkThreadContextMenuButton.tsx
@@ -1,0 +1,70 @@
+import { EllipsisVerticalIcon } from "lucide-react";
+import { type MouseEvent, type PointerEvent, useCallback } from "react";
+
+import { cn } from "~/lib/utils";
+
+export interface ForkThreadContextMenuButtonProps {
+  threadTitle: string;
+  isHighlighted: boolean;
+  onOpenFromAnchor: (position: { x: number; y: number }) => void;
+}
+
+export function stopThreadContextMenuButtonPointerDown(event: {
+  stopPropagation: () => void;
+}): void {
+  event.stopPropagation();
+}
+
+export function openThreadContextMenuFromButton(
+  event: {
+    preventDefault: () => void;
+    stopPropagation: () => void;
+    currentTarget: {
+      getBoundingClientRect: () => Pick<DOMRect, "right" | "bottom">;
+    };
+  },
+  onOpenFromAnchor: (position: { x: number; y: number }) => void,
+): void {
+  event.preventDefault();
+  event.stopPropagation();
+
+  const rect = event.currentTarget.getBoundingClientRect();
+  onOpenFromAnchor({
+    x: Math.round(rect.right),
+    y: Math.round(rect.bottom + 4),
+  });
+}
+
+export default function ForkThreadContextMenuButton({
+  threadTitle,
+  isHighlighted,
+  onOpenFromAnchor,
+}: ForkThreadContextMenuButtonProps) {
+  const handlePointerDown = useCallback((event: PointerEvent<HTMLButtonElement>) => {
+    stopThreadContextMenuButtonPointerDown(event);
+  }, []);
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      openThreadContextMenuFromButton(event, onOpenFromAnchor);
+    },
+    [onOpenFromAnchor],
+  );
+
+  return (
+    <button
+      type="button"
+      aria-label={`Open thread actions for ${threadTitle}`}
+      className={cn(
+        "pointer-coarse:opacity-100 inline-flex size-5 shrink-0 items-center justify-center rounded-md text-[10px] text-muted-foreground/40 transition-[opacity,color,background-color] hover:bg-accent/70 focus-visible:bg-accent/70 focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring active:bg-accent/80 sm:size-4.5 sm:opacity-0 sm:group-hover/thread-row:opacity-100 sm:group-focus-within/thread-row:opacity-100",
+        isHighlighted && "opacity-100 text-foreground/72 dark:text-foreground/82",
+      )}
+      onPointerDown={handlePointerDown}
+      onClick={handleClick}
+      data-thread-selection-safe
+      data-slot="fork-thread-context-menu-button"
+    >
+      <EllipsisVerticalIcon className="size-3.5" />
+    </button>
+  );
+}

--- a/apps/web/src/features/tts/AssistantMessageTtsButton.tsx
+++ b/apps/web/src/features/tts/AssistantMessageTtsButton.tsx
@@ -1,0 +1,62 @@
+import { memo } from "react";
+import { PlayIcon, SquareIcon } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { useMessageTts } from "./useMessageTts";
+
+export const AssistantMessageTtsButton = memo(function AssistantMessageTtsButton({
+  messageId,
+  text,
+}: {
+  messageId: string;
+  text: string;
+}) {
+  const {
+    supported,
+    canPlay,
+    isPlaying,
+    playbackRate,
+    playbackRateOptions,
+    setPlaybackRate,
+    title,
+    toggle,
+  } = useMessageTts(messageId, text);
+
+  if (!supported || !canPlay) {
+    return null;
+  }
+
+  return (
+    <div className="inline-flex items-center gap-1.5" data-slot="assistant-message-tts">
+      <Button
+        type="button"
+        size="xs"
+        variant="outline"
+        title={title}
+        aria-label={title}
+        aria-pressed={isPlaying}
+        onClick={toggle}
+      >
+        {isPlaying ? <SquareIcon className="size-3" /> : <PlayIcon className="size-3" />}
+      </Button>
+      {isPlaying ? (
+        <label className="inline-flex items-center gap-1 text-[10px] text-muted-foreground/70">
+          <span className="sr-only">Playback speed</span>
+          <select
+            aria-label="Playback speed"
+            className="h-7 rounded-md border border-border bg-background px-2 text-[10px] text-foreground outline-none transition-colors focus-visible:ring-1 focus-visible:ring-ring"
+            value={playbackRate.toFixed(1)}
+            onChange={(event) => {
+              setPlaybackRate(Number(event.target.value));
+            }}
+          >
+            {playbackRateOptions.map((rate) => (
+              <option key={rate} value={rate.toFixed(1)}>
+                {rate.toFixed(1)}x
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+    </div>
+  );
+});

--- a/apps/web/src/features/tts/nativeSpeechSynthesis.ts
+++ b/apps/web/src/features/tts/nativeSpeechSynthesis.ts
@@ -1,0 +1,141 @@
+export interface NativeSpeechSpeakInput {
+  readonly text: string;
+  readonly lang?: string;
+  readonly rate?: number;
+  readonly onEnd: () => void;
+  readonly onError: (error: Error) => void;
+}
+
+export interface NativeSpeechController {
+  readonly isSupported: () => boolean;
+  readonly speak: (input: NativeSpeechSpeakInput) => void;
+  readonly stop: () => void;
+}
+
+type SpeechUtteranceWithEvents = SpeechSynthesisUtterance &
+  Partial<EventTarget> & {
+    onend: null | (() => void);
+    onerror: null | ((event: { error?: string }) => void);
+  };
+
+function getSpeechEnvironment(): {
+  readonly speechSynthesis?: SpeechSynthesis;
+  readonly SpeechSynthesisUtterance?: typeof SpeechSynthesisUtterance;
+  readonly navigator?: Navigator;
+  readonly document?: Document;
+} {
+  const candidate = globalThis as typeof globalThis & {
+    speechSynthesis?: SpeechSynthesis;
+    SpeechSynthesisUtterance?: typeof SpeechSynthesisUtterance;
+    navigator?: Navigator;
+    document?: Document;
+  };
+
+  return {
+    speechSynthesis: candidate.speechSynthesis,
+    SpeechSynthesisUtterance: candidate.SpeechSynthesisUtterance,
+    navigator: candidate.navigator,
+    document: candidate.document,
+  };
+}
+
+function resolveSpeechLang(explicitLang?: string): string | undefined {
+  const lang = explicitLang?.trim();
+  if (lang) {
+    return lang;
+  }
+
+  const environment = getSpeechEnvironment();
+  const documentLang = environment.document?.documentElement.lang?.trim();
+  if (documentLang) {
+    return documentLang;
+  }
+
+  const navigatorLang = environment.navigator?.language?.trim();
+  return navigatorLang || undefined;
+}
+
+function selectVoice(
+  speechSynthesis: SpeechSynthesis,
+  lang: string | undefined,
+): SpeechSynthesisVoice | null {
+  const voices = speechSynthesis.getVoices();
+  if (voices.length === 0) {
+    return null;
+  }
+
+  if (!lang) {
+    return voices.find((voice) => voice.default) ?? voices[0] ?? null;
+  }
+
+  const normalizedLang = lang.toLowerCase();
+  const primaryLanguage = normalizedLang.split("-")[0];
+  const exactMatch = voices.find((voice) => voice.lang.toLowerCase() === normalizedLang);
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const primaryMatch = voices.find((voice) =>
+    voice.lang.toLowerCase().startsWith(`${primaryLanguage}-`),
+  );
+  if (primaryMatch) {
+    return primaryMatch;
+  }
+
+  return voices.find((voice) => voice.default) ?? voices[0] ?? null;
+}
+
+export function createNativeSpeechController(): NativeSpeechController {
+  return {
+    isSupported() {
+      const environment = getSpeechEnvironment();
+      return Boolean(environment.speechSynthesis && environment.SpeechSynthesisUtterance);
+    },
+
+    speak(input) {
+      const environment = getSpeechEnvironment();
+      if (!environment.speechSynthesis || !environment.SpeechSynthesisUtterance) {
+        throw new Error("Speech synthesis unavailable.");
+      }
+
+      const utterance = new environment.SpeechSynthesisUtterance(input.text);
+      const lang = resolveSpeechLang(input.lang);
+      if (lang) {
+        utterance.lang = lang;
+      }
+
+      const voice = selectVoice(environment.speechSynthesis, utterance.lang || lang);
+      if (voice) {
+        utterance.voice = voice;
+      }
+      if (typeof input.rate === "number" && Number.isFinite(input.rate)) {
+        utterance.rate = input.rate;
+      }
+
+      const handleEnd = () => {
+        input.onEnd();
+      };
+      const handleError = (event: Event) => {
+        const speechEvent = event as SpeechSynthesisErrorEvent;
+        input.onError(new Error(speechEvent.error ?? "Speech synthesis failed."));
+      };
+      const eventfulUtterance = utterance as SpeechUtteranceWithEvents;
+      if (typeof eventfulUtterance.addEventListener === "function") {
+        eventfulUtterance.addEventListener("end", handleEnd);
+        eventfulUtterance.addEventListener("error", handleError);
+      } else {
+        eventfulUtterance.onend = handleEnd;
+        eventfulUtterance.onerror = (event) => {
+          handleError({ error: event.error } as SpeechSynthesisErrorEvent);
+        };
+      }
+
+      environment.speechSynthesis.speak(utterance);
+    },
+
+    stop() {
+      const environment = getSpeechEnvironment();
+      environment.speechSynthesis?.cancel();
+    },
+  };
+}

--- a/apps/web/src/features/tts/sanitizeTtsText.test.ts
+++ b/apps/web/src/features/tts/sanitizeTtsText.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeAssistantMessageForTts } from "./sanitizeTtsText";
+
+describe("sanitizeAssistantMessageForTts", () => {
+  it("preserves plain prose while normalizing whitespace", () => {
+    expect(sanitizeAssistantMessageForTts("Hello   world.\n\n")).toBe("Hello world.");
+  });
+
+  it("keeps markdown link labels and drops URLs", () => {
+    expect(
+      sanitizeAssistantMessageForTts("Read [the docs](https://example.com/docs) for more details."),
+    ).toBe("Read the docs for more details.");
+  });
+
+  it("flattens inline code into readable prose", () => {
+    expect(sanitizeAssistantMessageForTts("Run `bun lint` before shipping.")).toBe(
+      "Run bun lint before shipping.",
+    );
+  });
+
+  it("replaces labeled code fences with a language-specific placeholder", () => {
+    expect(sanitizeAssistantMessageForTts("```ts\nconst value = 1;\n```")).toBe(
+      "TypeScript Code Block - Open the chat to view the code.",
+    );
+  });
+
+  it("replaces unlabeled code fences with a generic placeholder", () => {
+    expect(sanitizeAssistantMessageForTts("```\nconst value = 1;\n```")).toBe(
+      "Code Block - Open the chat to view the code.",
+    );
+  });
+
+  it("replaces multiple code fences independently", () => {
+    expect(
+      sanitizeAssistantMessageForTts(
+        ["```python", "print('hi')", "```", "", "```sh", "echo hi", "```"].join("\n"),
+      ),
+    ).toBe(
+      [
+        "Python Code Block - Open the chat to view the code.",
+        "",
+        "Shell Code Block - Open the chat to view the code.",
+      ].join("\n"),
+    );
+  });
+
+  it("returns empty string for markdown-only filler without speakable text", () => {
+    expect(sanitizeAssistantMessageForTts("###\n\n---\n\n>")).toBe("");
+  });
+});

--- a/apps/web/src/features/tts/sanitizeTtsText.ts
+++ b/apps/web/src/features/tts/sanitizeTtsText.ts
@@ -1,0 +1,106 @@
+const CODE_BLOCK_SUFFIX = "Code Block - Open the chat to view the code.";
+
+const CODE_LANGUAGE_LABELS: Record<string, string> = {
+  bash: "Shell",
+  c: "C",
+  "c#": "C Sharp",
+  "c++": "C Plus Plus",
+  cpp: "C Plus Plus",
+  cs: "C Sharp",
+  css: "CSS",
+  go: "Go",
+  html: "HTML",
+  java: "Java",
+  javascript: "JavaScript",
+  js: "JavaScript",
+  json: "JSON",
+  jsx: "JavaScript",
+  markdown: "Markdown",
+  md: "Markdown",
+  php: "PHP",
+  py: "Python",
+  python: "Python",
+  rb: "Ruby",
+  ruby: "Ruby",
+  rust: "Rust",
+  sh: "Shell",
+  shell: "Shell",
+  sql: "SQL",
+  swift: "Swift",
+  ts: "TypeScript",
+  tsx: "TypeScript",
+  typescript: "TypeScript",
+  xml: "XML",
+  yaml: "YAML",
+  yml: "YAML",
+  zsh: "Shell",
+};
+
+function normalizeLanguageLabel(infoString: string): string | null {
+  const languageToken = infoString.trim().split(/\s+/)[0]?.trim().toLowerCase();
+  if (!languageToken) {
+    return null;
+  }
+
+  const knownLabel = CODE_LANGUAGE_LABELS[languageToken];
+  if (knownLabel) {
+    return knownLabel;
+  }
+
+  const cleaned = languageToken.replace(/[^a-z0-9#+.-]/gi, "");
+  if (!cleaned || !/[a-z]/i.test(cleaned)) {
+    return null;
+  }
+
+  return cleaned
+    .split(/[-_.]+/)
+    .filter((segment) => segment.length > 0)
+    .map((segment) => `${segment.slice(0, 1).toUpperCase()}${segment.slice(1)}`)
+    .join(" ");
+}
+
+function buildCodeBlockPlaceholder(infoString: string): string {
+  const languageLabel = normalizeLanguageLabel(infoString);
+  if (!languageLabel) {
+    return CODE_BLOCK_SUFFIX;
+  }
+
+  return `${languageLabel} ${CODE_BLOCK_SUFFIX}`;
+}
+
+function hasSpeakableText(value: string): boolean {
+  return value.replace(/[^\p{L}\p{N}]+/gu, "").length > 0;
+}
+
+export function sanitizeAssistantMessageForTts(text: string): string {
+  let sanitized = text.trim();
+  if (sanitized.length === 0) {
+    return "";
+  }
+
+  sanitized = sanitized.replace(
+    /(^|\n)(```|~~~)([^\n]*)\n[\s\S]*?\n\2(?=\n|$)/g,
+    (_match, leadingBoundary: string, _fence: string, infoString: string) =>
+      `${leadingBoundary}${buildCodeBlockPlaceholder(infoString)}\n`,
+  );
+
+  sanitized = sanitized.replace(/!\[([^\]]*)\]\((?:[^()\\]|\\.)+\)/g, "$1");
+  sanitized = sanitized.replace(/\[([^\]]+)\]\((?:[^()\\]|\\.)+\)/g, "$1");
+  sanitized = sanitized.replace(/<https?:\/\/[^>\s]+>/g, "");
+  sanitized = sanitized.replace(/https?:\/\/\S+/g, "");
+  sanitized = sanitized.replace(/`([^`]+)`/g, "$1");
+  sanitized = sanitized.replace(/^#{1,6}\s+/gm, "");
+  sanitized = sanitized.replace(/^>\s?/gm, "");
+  sanitized = sanitized.replace(/^[-*+]\s+/gm, "");
+  sanitized = sanitized.replace(/^\d+\.\s+/gm, "");
+  sanitized = sanitized.replace(/^[-*_]{3,}$/gm, "");
+  sanitized = sanitized.replace(/[*_~]/g, "");
+  sanitized = sanitized.replace(/<\/?[^>]+>/g, "");
+  sanitized = sanitized.replace(/[ \t]*\|[ \t]*/g, " ");
+  sanitized = sanitized.replace(/[ \t]+\n/g, "\n");
+  sanitized = sanitized.replace(/\n{3,}/g, "\n\n");
+  sanitized = sanitized.replace(/[ \t]{2,}/g, " ");
+  sanitized = sanitized.trim();
+
+  return hasSpeakableText(sanitized) ? sanitized : "";
+}

--- a/apps/web/src/features/tts/tts.test.ts
+++ b/apps/web/src/features/tts/tts.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getSnapshot,
+  isSupported,
+  setPlaybackRate,
+  stopPlayback,
+  toggleMessagePlayback,
+} from "./tts";
+
+class MockSpeechSynthesisUtterance {
+  readonly text: string;
+  lang = "";
+  rate = 1;
+  voice: SpeechSynthesisVoice | null = null;
+  onend: (() => void) | null = null;
+  onerror: ((event: { error?: string }) => void) | null = null;
+
+  constructor(text: string) {
+    this.text = text;
+  }
+}
+
+interface SpeechMockState {
+  readonly speakCalls: MockSpeechSynthesisUtterance[];
+  cancelCount: number;
+}
+
+const speechSynthesisDescriptor = Object.getOwnPropertyDescriptor(globalThis, "speechSynthesis");
+const utteranceDescriptor = Object.getOwnPropertyDescriptor(globalThis, "SpeechSynthesisUtterance");
+
+function restoreSpeechGlobals(): void {
+  if (speechSynthesisDescriptor) {
+    Object.defineProperty(globalThis, "speechSynthesis", speechSynthesisDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "speechSynthesis");
+  }
+
+  if (utteranceDescriptor) {
+    Object.defineProperty(globalThis, "SpeechSynthesisUtterance", utteranceDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "SpeechSynthesisUtterance");
+  }
+}
+
+function installSpeechMock(): SpeechMockState {
+  const state: SpeechMockState = {
+    speakCalls: [],
+    cancelCount: 0,
+  };
+
+  Object.defineProperty(globalThis, "speechSynthesis", {
+    configurable: true,
+    value: {
+      cancel: vi.fn(() => {
+        state.cancelCount += 1;
+      }),
+      getVoices: vi.fn(() => []),
+      speak: vi.fn((utterance: SpeechSynthesisUtterance) => {
+        state.speakCalls.push(utterance as unknown as MockSpeechSynthesisUtterance);
+      }),
+    } satisfies Partial<SpeechSynthesis>,
+  });
+  Object.defineProperty(globalThis, "SpeechSynthesisUtterance", {
+    configurable: true,
+    value: MockSpeechSynthesisUtterance as unknown as typeof SpeechSynthesisUtterance,
+  });
+
+  return state;
+}
+
+describe("tts", () => {
+  beforeEach(() => {
+    restoreSpeechGlobals();
+    stopPlayback();
+  });
+
+  afterEach(() => {
+    restoreSpeechGlobals();
+    stopPlayback();
+  });
+
+  it("reports unsupported state when native speech synthesis is unavailable", () => {
+    expect(isSupported()).toBe(false);
+    expect(getSnapshot().status).toBe("unsupported");
+  });
+
+  it("starts playback for a message and exposes the active snapshot", () => {
+    const speech = installSpeechMock();
+
+    toggleMessagePlayback({
+      messageId: "message-1",
+      text: "Read this response aloud.",
+    });
+
+    expect(speech.speakCalls).toHaveLength(1);
+    expect(speech.speakCalls[0]?.text).toBe("Read this response aloud.");
+    expect(speech.speakCalls[0]?.rate).toBe(1);
+    expect(getSnapshot()).toMatchObject({
+      status: "playing",
+      activeMessageId: "message-1",
+      provider: "native",
+      playbackRate: 1,
+    });
+  });
+
+  it("stops playback when toggling the active message again", () => {
+    const speech = installSpeechMock();
+
+    toggleMessagePlayback({
+      messageId: "message-1",
+      text: "Read this response aloud.",
+    });
+    toggleMessagePlayback({
+      messageId: "message-1",
+      text: "Read this response aloud.",
+    });
+
+    expect(speech.cancelCount).toBe(2);
+    expect(getSnapshot().status).toBe("idle");
+    expect(getSnapshot().activeMessageId).toBeNull();
+  });
+
+  it("switches playback to a different message and ignores stale completion callbacks", () => {
+    const speech = installSpeechMock();
+
+    toggleMessagePlayback({
+      messageId: "message-1",
+      text: "First message.",
+    });
+    const firstUtterance = speech.speakCalls[0]!;
+
+    toggleMessagePlayback({
+      messageId: "message-2",
+      text: "Second message.",
+    });
+
+    firstUtterance.onend?.();
+
+    expect(speech.cancelCount).toBe(2);
+    expect(speech.speakCalls).toHaveLength(2);
+    expect(getSnapshot()).toMatchObject({
+      status: "playing",
+      activeMessageId: "message-2",
+    });
+  });
+
+  it("restarts the active utterance when playback rate changes", () => {
+    const speech = installSpeechMock();
+
+    toggleMessagePlayback({
+      messageId: "message-1",
+      text: "Read this response aloud.",
+    });
+    setPlaybackRate(1.4);
+
+    expect(speech.cancelCount).toBe(2);
+    expect(speech.speakCalls).toHaveLength(2);
+    expect(speech.speakCalls[1]?.rate).toBe(1.4);
+    expect(getSnapshot()).toMatchObject({
+      status: "playing",
+      activeMessageId: "message-1",
+      playbackRate: 1.4,
+    });
+  });
+});

--- a/apps/web/src/features/tts/tts.ts
+++ b/apps/web/src/features/tts/tts.ts
@@ -1,0 +1,211 @@
+import { createNativeSpeechController } from "./nativeSpeechSynthesis";
+
+export type TtsProviderKind = "native" | "openai" | "elevenlabs";
+export type TtsPlaybackStatus = "idle" | "playing" | "unsupported" | "error";
+
+export interface TtsSnapshot {
+  readonly status: TtsPlaybackStatus;
+  readonly activeMessageId: string | null;
+  readonly provider: TtsProviderKind;
+  readonly playbackRate: number;
+  readonly errorMessage?: string;
+}
+
+export interface SpeakMessageInput {
+  readonly messageId: string;
+  readonly text: string;
+  readonly lang?: string;
+}
+
+const listeners = new Set<() => void>();
+const DEFAULT_PLAYBACK_RATE = 1.0;
+const MIN_PLAYBACK_RATE = 0.8;
+const MAX_PLAYBACK_RATE = 2.0;
+const PLAYBACK_RATE_STEP = 0.1;
+
+let playbackGeneration = 0;
+let playbackRate = DEFAULT_PLAYBACK_RATE;
+let activeSpeakInput: SpeakMessageInput | null = null;
+let snapshot: TtsSnapshot = {
+  status: "idle",
+  activeMessageId: null,
+  provider: "native",
+  playbackRate,
+};
+
+function emitChange(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function setSnapshot(nextSnapshot: TtsSnapshot): void {
+  snapshot = nextSnapshot;
+  emitChange();
+}
+
+function buildIdleSnapshot(): TtsSnapshot {
+  return {
+    status: "idle",
+    activeMessageId: null,
+    provider: "native",
+    playbackRate,
+  };
+}
+
+function asError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(typeof error === "string" ? error : "Speech synthesis failed.");
+}
+
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function isSupported(): boolean {
+  return createNativeSpeechController().isSupported();
+}
+
+export function getPlaybackRateOptions(): ReadonlyArray<number> {
+  const rates: number[] = [];
+  for (
+    let rate = MIN_PLAYBACK_RATE;
+    rate <= MAX_PLAYBACK_RATE + 0.0001;
+    rate += PLAYBACK_RATE_STEP
+  ) {
+    rates.push(Number(rate.toFixed(1)));
+  }
+  return rates;
+}
+
+function clampPlaybackRate(rate: number): number {
+  if (!Number.isFinite(rate)) {
+    return playbackRate;
+  }
+
+  const clamped = Math.min(MAX_PLAYBACK_RATE, Math.max(MIN_PLAYBACK_RATE, rate));
+  return Number((Math.round(clamped / PLAYBACK_RATE_STEP) * PLAYBACK_RATE_STEP).toFixed(1));
+}
+
+export function getSnapshot(): TtsSnapshot {
+  if (!isSupported() && snapshot.status === "idle") {
+    return {
+      ...snapshot,
+      status: "unsupported",
+    };
+  }
+
+  return snapshot;
+}
+
+export function stopPlayback(): void {
+  playbackGeneration += 1;
+  activeSpeakInput = null;
+  createNativeSpeechController().stop();
+  setSnapshot(buildIdleSnapshot());
+}
+
+function startPlayback(input: SpeakMessageInput): void {
+  const trimmedText = input.text.trim();
+  if (trimmedText.length === 0) {
+    return;
+  }
+
+  const controller = createNativeSpeechController();
+  if (!controller.isSupported()) {
+    setSnapshot({
+      status: "unsupported",
+      activeMessageId: null,
+      provider: "native",
+      playbackRate,
+    });
+    return;
+  }
+
+  const nextGeneration = playbackGeneration + 1;
+  playbackGeneration = nextGeneration;
+  controller.stop();
+  activeSpeakInput = {
+    ...input,
+    text: trimmedText,
+  };
+  setSnapshot({
+    status: "playing",
+    activeMessageId: input.messageId,
+    provider: "native",
+    playbackRate,
+  });
+
+  try {
+    controller.speak({
+      text: trimmedText,
+      ...(input.lang ? { lang: input.lang } : {}),
+      rate: playbackRate,
+      onEnd: () => {
+        if (playbackGeneration !== nextGeneration) {
+          return;
+        }
+        activeSpeakInput = null;
+        setSnapshot(buildIdleSnapshot());
+      },
+      onError: (error) => {
+        if (playbackGeneration !== nextGeneration) {
+          return;
+        }
+        activeSpeakInput = null;
+        setSnapshot({
+          status: "error",
+          activeMessageId: null,
+          provider: "native",
+          playbackRate,
+          errorMessage: error.message,
+        });
+      },
+    });
+  } catch (error) {
+    if (playbackGeneration !== nextGeneration) {
+      return;
+    }
+    const resolvedError = asError(error);
+    setSnapshot({
+      status: "error",
+      activeMessageId: null,
+      provider: "native",
+      playbackRate,
+      errorMessage: resolvedError.message,
+    });
+  }
+}
+
+export function setPlaybackRate(rate: number): void {
+  const nextRate = clampPlaybackRate(rate);
+  if (nextRate === playbackRate) {
+    return;
+  }
+
+  playbackRate = nextRate;
+  if (activeSpeakInput && snapshot.status === "playing") {
+    startPlayback(activeSpeakInput);
+    return;
+  }
+
+  setSnapshot({
+    ...snapshot,
+    playbackRate,
+  });
+}
+
+export function toggleMessagePlayback(input: SpeakMessageInput): void {
+  if (snapshot.status === "playing" && snapshot.activeMessageId === input.messageId) {
+    stopPlayback();
+    return;
+  }
+
+  startPlayback(input);
+}

--- a/apps/web/src/features/tts/useMessageTts.ts
+++ b/apps/web/src/features/tts/useMessageTts.ts
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from "react";
+import { sanitizeAssistantMessageForTts } from "./sanitizeTtsText";
+import {
+  getPlaybackRateOptions,
+  getSnapshot,
+  isSupported,
+  setPlaybackRate,
+  subscribe,
+  toggleMessagePlayback,
+} from "./tts";
+
+export function useMessageTts(messageId: string, text: string) {
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const sanitizedText = sanitizeAssistantMessageForTts(text);
+  const supported = isSupported();
+  const isPlaying = snapshot.status === "playing" && snapshot.activeMessageId === messageId;
+  const canPlay = supported && sanitizedText.length > 0;
+
+  return {
+    supported,
+    isPlaying,
+    canPlay,
+    playbackRate: snapshot.playbackRate,
+    playbackRateOptions: getPlaybackRateOptions(),
+    title: isPlaying ? "Stop playback" : "Play message",
+    setPlaybackRate,
+    toggle() {
+      if (!canPlay) {
+        return;
+      }
+
+      toggleMessagePlayback({
+        messageId,
+        text: sanitizedText,
+      });
+    },
+  } as const;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,6 +5,7 @@ import { createHashHistory, createBrowserHistory } from "@tanstack/react-router"
 
 import "@xterm/xterm/css/xterm.css";
 import "./index.css";
+import "./overrides.css";
 
 import { isElectron } from "./env";
 import { installForkWebShell } from "./fork/bootstrap";

--- a/apps/web/src/overrides.css
+++ b/apps/web/src/overrides.css
@@ -1,0 +1,212 @@
+/* Fork-owned mobile/sidebar polish kept isolated from upstream utility classes. */
+
+[data-mobile="true"][data-slot="sidebar"] {
+  max-width: 92vw;
+  border-radius: 12px 12px 24px 12px;
+  corner-shape: squircle;
+}
+
+[data-projects-heading] {
+  margin-bottom: 0.55rem;
+  padding-bottom: 0.45rem;
+}
+
+[data-projects-list] {
+  gap: 0.45rem;
+}
+
+[data-project-header] {
+  margin-right: -0.5rem;
+}
+
+[data-project-row] {
+  border: 1px solid color-mix(in srgb, var(--foreground) 6%, transparent);
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-right: 2.15rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--foreground) 5%, transparent) 0%,
+    color-mix(in srgb, var(--foreground) 3%, transparent) 100%
+  );
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-white) 3%, transparent);
+}
+
+[data-project-row]:hover,
+[data-project-row]:focus-visible {
+  border-color: color-mix(in srgb, var(--foreground) 9%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--foreground) 7%, transparent) 0%,
+    color-mix(in srgb, var(--foreground) 4%, transparent) 100%
+  );
+}
+
+[data-project-action] {
+  right: 0.8rem;
+}
+
+[data-project-threads] {
+  margin-top: 0.2rem;
+}
+
+[data-project-threads] > [data-thread-item]:first-child {
+  margin-top: 0.3rem;
+}
+
+.dark [data-project-row] {
+  border-color: color-mix(in srgb, var(--color-white) 7%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-white) 6%, transparent) 0%,
+    color-mix(in srgb, var(--color-white) 3.5%, transparent) 100%
+  );
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-white) 4%, transparent);
+}
+
+.dark [data-project-row]:hover,
+.dark [data-project-row]:focus-visible {
+  border-color: color-mix(in srgb, var(--color-white) 10%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-white) 8%, transparent) 0%,
+    color-mix(in srgb, var(--color-white) 4.5%, transparent) 100%
+  );
+}
+
+:root[data-host-variant="t3-dev"] [data-slot="fork-stage-badge"] {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.1rem;
+  padding-inline: 0.42rem;
+  padding-block: 0.18rem;
+  background: color-mix(in srgb, var(--color-red-500) 12%, transparent);
+  color: transparent;
+  font-size: 0;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+:root[data-host-variant="t3-dev"] [data-slot="fork-stage-badge"]::after {
+  content: "DEVELOP";
+  color: color-mix(in srgb, var(--color-red-600) 82%, var(--foreground));
+  font-size: 8px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.16em;
+  transform: translateY(0.5px);
+}
+
+:root.dark[data-host-variant="t3-dev"] [data-slot="fork-stage-badge"] {
+  background: color-mix(in srgb, var(--color-red-500) 18%, transparent);
+}
+
+:root.dark[data-host-variant="t3-dev"] [data-slot="fork-stage-badge"]::after {
+  color: color-mix(in srgb, var(--color-red-400) 88%, var(--foreground));
+}
+
+@media (display-mode: standalone) and (max-width: 768px) {
+  body::before {
+    content: "";
+    position: fixed;
+    inset: env(safe-area-inset-top, 0px) 0 0 0;
+    z-index: 40;
+    pointer-events: none;
+    border-radius: 12px 12px 24px 24px;
+    corner-shape: squircle;
+    box-shadow: 0 0 0 100vmax var(--t3-boot-mid, #07101f);
+  }
+
+  html::after {
+    content: "";
+    position: fixed;
+    inset: env(safe-area-inset-top, 0px) 0 0 0;
+    z-index: 42;
+    pointer-events: none;
+    border-radius: 12px 12px 24px 24px;
+    corner-shape: squircle;
+    box-shadow:
+      inset 0 0 0 0.5px color-mix(in srgb, var(--color-white) 45%, transparent),
+      inset 0 0 0 1px color-mix(in srgb, var(--color-black) 15%, transparent);
+  }
+
+  html.dark::after {
+    box-shadow:
+      inset 0 0 0 0.5px color-mix(in srgb, var(--color-white) 25%, transparent),
+      inset 0 0 0 1px color-mix(in srgb, var(--color-black) 40%, transparent);
+  }
+
+  [data-slot="sheet-backdrop"] {
+    border-radius: 12px 12px 24px 24px;
+    corner-shape: squircle;
+  }
+
+  [data-mobile="true"][data-slot="sidebar"] {
+    box-shadow:
+      inset -0.5px 0 0 0 color-mix(in srgb, var(--color-white) 45%, transparent),
+      inset -1px 0 0 0 color-mix(in srgb, var(--color-black) 15%, transparent);
+  }
+
+  .dark [data-mobile="true"][data-slot="sidebar"] {
+    box-shadow:
+      inset -0.5px 0 0 0 color-mix(in srgb, var(--color-white) 25%, transparent),
+      inset -1px 0 0 0 color-mix(in srgb, var(--color-black) 40%, transparent);
+  }
+
+  [data-mobile="true"][data-slot="sidebar"] [data-slot="sidebar-footer"] {
+    align-items: center;
+  }
+
+  [data-mobile="true"][data-slot="sidebar"]
+    [data-slot="sidebar-footer"]
+    [data-slot="sidebar-menu"] {
+    width: auto;
+  }
+
+  [data-mobile="true"][data-slot="sidebar"]
+    [data-slot="sidebar-footer"]
+    [data-slot="sidebar-menu-button"] {
+    justify-content: center;
+    border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+    box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-white) 4%, transparent);
+    text-align: center;
+  }
+
+  .dark
+    [data-mobile="true"][data-slot="sidebar"]
+    [data-slot="sidebar-footer"]
+    [data-slot="sidebar-menu-button"] {
+    border-color: color-mix(in srgb, var(--color-white) 12%, transparent);
+    box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-white) 6%, transparent);
+  }
+}
+
+@media (hover: none) {
+  [data-slot="thread-rename-input"] {
+    font-size: 16px;
+  }
+
+  .chat-markdown .chat-markdown-copy-button {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  [data-project-action] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  [data-slot="user-message-actions"],
+  [data-slot="thread-terminal-close-action"],
+  [data-slot="custom-model-remove-action"] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  [data-project-status] {
+    opacity: 0;
+    pointer-events: none;
+  }
+}


### PR DESCRIPTION
## Summary
- restore the fork-owned mobile/sidebar polish layer and thread touch affordances
- bring back native assistant message TTS and touch-visible message actions
- reapply the remaining UI/mobile fork seams on top of the fresh-upstream bootstrap shell

## Verification
- bun fmt
- bun lint
- bun typecheck
- bun run --cwd apps/web test src/components/Sidebar.logic.test.ts src/components/sidebar/ForkThreadContextMenuButton.test.tsx src/components/chat/MessagesTimeline.test.tsx src/components/chat/MessagesTimeline.logic.test.ts src/features/tts/tts.test.ts src/features/tts/sanitizeTtsText.test.ts

## Review notes
- reviewed by multiple subagents before push
- fixed follow-up finding around desktop hover/focus reveal for the sidebar thread overflow button
