### PR TITLE
Phase 6: restore fork diagnostics sidecars

### DIFF
--- a/ENHANCEMENTS.md
+++ b/ENHANCEMENTS.md
@@ -242,6 +242,24 @@ For the detailed historical changelog from the initial fork buildout (March 2026
 - Verify: create a thread awaiting structured user input — sidebar pill reads "Awaiting Input" with red text/dot styling; pending approvals remain amber
 - Rollback: revert the awaiting-input `colorClass` and `dotClass` in `resolveThreadStatusPill`
 
+#### Fork Diagnostics Sidecar
+
+- Status: active | Added: 2026-03-26 | Updated: 2026-04-26
+- Upstream impact: low
+- Why: Fork-only debugging for user-input callbacks and client-side failures should be available behind a dev/local sidecar without editing the URL manually or widening upstream runtime codepaths.
+- Seam: `apps/web/src/routes/__root.tsx`, `apps/web/src/fork/bootstrap/ForkRootSidecars.tsx`, `apps/web/src/settings/ForkSettingsSection.tsx`
+- Files:
+  - `apps/web/src/debug/userInputDebug.ts`, `apps/web/src/debug/crashDebug.ts`, `apps/web/src/debug/crashDebug.test.ts`, `apps/web/src/debug/UserInputDebugSidecar.tsx`
+  - `apps/web/src/components/debug/UserInputDebugPanel.tsx`
+  - `apps/web/src/fork/bootstrap/ForkRootSidecars.tsx`, `apps/web/src/fork/bootstrap/rootDebug.ts`, `apps/web/src/fork/bootstrap/rootDebug.test.ts`, `apps/web/src/fork/bootstrap/index.ts`
+  - `apps/web/src/routes/__root.tsx`, `apps/web/src/environments/runtime/service.ts`
+  - `apps/web/src/settings/ForkSettingsSection.tsx`, `apps/web/src/settings/ForkSettingsSection.browser.tsx`
+- Upstream replacement trigger: upstream adds first-class client diagnostics for user-input callback failures and crash breadcrumbs
+- Verify: open Settings and use `Open panel`; load with `?debugUserInput=1` on dev/local and confirm the panel appears; trigger a `provider.user-input.respond.failed` activity and confirm the warning toast plus debug breadcrumb capture
+- Rollback: remove `ForkRootSidecars` mount and diagnostics row; delete `apps/web/src/debug/*` if removing the sidecar completely
+- Notes:
+  - 2026-04-26: This intentionally keeps stale pending-request cleanup out of the fork. The retained behavior is the floating diagnostics sidecar, root error/crash breadcrumbs, and user-input event logging only.
+
 #### Native Assistant Message TTS
 
 - Status: active | Added: 2026-03-16 | Updated: 2026-03-23

--- a/apps/web/src/components/debug/ForkRootSidecars.browser.tsx
+++ b/apps/web/src/components/debug/ForkRootSidecars.browser.tsx
@@ -1,0 +1,43 @@
+import "../../index.css";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+vi.mock("./UserInputDebugPanel", () => ({
+  UserInputDebugPanel: () => <div>Debug panel</div>,
+}));
+
+import { loadCrashBreadcrumbSessions } from "../../debug/crashDebug";
+import { ForkRootSidecars } from "../../fork/bootstrap";
+
+const CRASH_DEBUG_STORAGE_KEY = "t3code:debug-crash-breadcrumbs";
+
+describe("ForkRootSidecars", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.removeItem(CRASH_DEBUG_STORAGE_KEY);
+    document.body.innerHTML = "";
+  });
+
+  it("initializes crash diagnostics when the sidecar mounts", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const screen = await render(<ForkRootSidecars />, { container: host });
+
+    let sessions = loadCrashBreadcrumbSessions();
+    for (let attempt = 0; attempt < 5 && sessions.length === 0; attempt += 1) {
+      await new Promise((resolve) => {
+        window.setTimeout(resolve, 10);
+      });
+      sessions = loadCrashBreadcrumbSessions();
+    }
+
+    expect(sessions.length).toBeGreaterThan(0);
+    expect(sessions[0]?.breadcrumbs.some((entry) => entry.stage === "debug-panel-mounted")).toBe(
+      true,
+    );
+
+    await screen.unmount();
+    host.remove();
+  });
+});

--- a/apps/web/src/components/debug/UserInputDebugPanel.tsx
+++ b/apps/web/src/components/debug/UserInputDebugPanel.tsx
@@ -1,0 +1,504 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } from "react";
+import { BrushCleaningIcon, CheckIcon, ChevronsUpDownIcon, CopyIcon, XIcon } from "lucide-react";
+
+import {
+  buildCrashBreadcrumbReport,
+  clearCrashBreadcrumbs,
+  loadCrashBreadcrumbSessions,
+  setSelectedCrashSession,
+  useCrashDebugStore,
+} from "~/debug/crashDebug";
+import {
+  clearUserInputDebugEntries,
+  setUserInputDebugCollapsed,
+  setUserInputDebugEnabled,
+  setUserInputDebugPosition,
+  useUserInputDebugStore,
+} from "~/debug/userInputDebug";
+import { Button } from "../ui/button";
+import { cn } from "~/lib/utils";
+
+function toneClass(level: "info" | "success" | "warning" | "error"): string {
+  switch (level) {
+    case "success":
+      return "bg-emerald-500/10 text-emerald-100";
+    case "warning":
+      return "bg-amber-500/10 text-amber-100";
+    case "error":
+      return "bg-rose-500/10 text-rose-100";
+    default:
+      return "bg-white/6 text-white/90";
+  }
+}
+
+function formatDetail(detail: string | undefined): string | null {
+  if (!detail) {
+    return null;
+  }
+  const trimmed = detail.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+type DebugPanelTab = "userInput" | "crash";
+
+function formatSessionDisposition(disposition: string): string {
+  switch (disposition) {
+    case "clean-exit":
+      return "Clean exit";
+    case "root-error":
+      return "Root error";
+    case "possible-renderer-crash":
+      return "Possible renderer crash";
+    default:
+      return "Active";
+  }
+}
+
+export function UserInputDebugPanel() {
+  const enabled = useUserInputDebugStore((store) => store.enabled);
+  const collapsed = useUserInputDebugStore((store) => store.collapsed);
+  const position = useUserInputDebugStore((store) => store.position);
+  const entries = useUserInputDebugStore((store) => store.entries);
+  const crashSessions = useCrashDebugStore((store) => store.sessions);
+  const selectedCrashSessionId = useCrashDebugStore((store) => store.selectedSessionId);
+  const [copied, setCopied] = useState(false);
+  const [activeTab, setActiveTab] = useState<DebugPanelTab>("userInput");
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dragStateRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+    width: number;
+    height: number;
+    moved: boolean;
+  } | null>(null);
+  const suppressClickRef = useRef(false);
+
+  const selectedCrashSession =
+    crashSessions.find((session) => session.id === selectedCrashSessionId) ??
+    crashSessions[0] ??
+    null;
+  const previousCrashSession = crashSessions[1] ?? null;
+
+  const copyUserInputEntries = useCallback(async () => {
+    const text = entries
+      .map((entry) =>
+        [
+          entry.timestamp,
+          entry.level.toUpperCase(),
+          entry.stage,
+          entry.message,
+          entry.threadId ? `thread=${entry.threadId}` : null,
+          entry.requestId ? `request=${entry.requestId}` : null,
+          entry.detail ? `detail=${entry.detail}` : null,
+        ]
+          .filter(Boolean)
+          .join(" | "),
+      )
+      .join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  }, [entries]);
+
+  const copyCrashEntries = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(
+        buildCrashBreadcrumbReport(selectedCrashSession?.id ?? null),
+      );
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  }, [selectedCrashSession?.id]);
+
+  const copyLatestForTab = useCallback(async () => {
+    if (activeTab === "crash") {
+      await copyCrashEntries();
+      return;
+    }
+    await copyUserInputEntries();
+  }, [activeTab, copyCrashEntries, copyUserInputEntries]);
+
+  const renderedEntries = useMemo(() => entries.toReversed(), [entries]);
+  const renderedCrashEntries = useMemo(
+    () => selectedCrashSession?.breadcrumbs.toReversed() ?? [],
+    [selectedCrashSession],
+  );
+
+  const updatePosition = useCallback(
+    (nextX: number, nextY: number, width: number, height: number) => {
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const margin = 8;
+      const clampedX = Math.min(
+        Math.max(margin, nextX),
+        Math.max(margin, viewportWidth - width - margin),
+      );
+      const clampedY = Math.min(
+        Math.max(margin, nextY),
+        Math.max(margin, viewportHeight - height - margin),
+      );
+      setUserInputDebugPosition({ x: clampedX, y: clampedY });
+    },
+    [],
+  );
+
+  const beginDrag = useCallback((event: PointerEvent<HTMLElement>) => {
+    if (event.button !== 0) {
+      return;
+    }
+    const element = containerRef.current;
+    if (!element) {
+      return;
+    }
+    const rect = element.getBoundingClientRect();
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: rect.left,
+      originY: rect.top,
+      width: rect.width,
+      height: rect.height,
+      moved: false,
+    };
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }, []);
+
+  const onDragMove = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      const dragState = dragStateRef.current;
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+      const deltaX = event.clientX - dragState.startX;
+      const deltaY = event.clientY - dragState.startY;
+      if (!dragState.moved && Math.abs(deltaX) + Math.abs(deltaY) > 6) {
+        dragState.moved = true;
+      }
+      updatePosition(
+        dragState.originX + deltaX,
+        dragState.originY + deltaY,
+        dragState.width,
+        dragState.height,
+      );
+      event.preventDefault();
+    },
+    [updatePosition],
+  );
+
+  const endDrag = useCallback((event: PointerEvent<HTMLElement>) => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return;
+    }
+    dragStateRef.current = null;
+    suppressClickRef.current = dragState.moved;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    window.setTimeout(() => {
+      suppressClickRef.current = false;
+    }, 0);
+  }, []);
+
+  // Re-clamp position when expanding from collapsed state so the wider
+  // panel doesn't overflow the viewport.
+  useEffect(() => {
+    if (!enabled || collapsed || !position) {
+      return;
+    }
+    // Wait one frame so the expanded panel has rendered and has its real size.
+    const raf = requestAnimationFrame(() => {
+      const element = containerRef.current;
+      if (!element) {
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      updatePosition(position.x, position.y, rect.width, rect.height);
+    });
+    return () => cancelAnimationFrame(raf);
+    // Only run when collapsed changes – not on every position update.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, collapsed]);
+
+  useEffect(() => {
+    if (!enabled || !position) {
+      return;
+    }
+    const onResize = () => {
+      const element = containerRef.current;
+      if (!element) {
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      updatePosition(position.x, position.y, rect.width, rect.height);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [enabled, position, updatePosition]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  const floatingStyle =
+    position === null
+      ? undefined
+      : {
+          left: `${position.x}px`,
+          top: `${position.y}px`,
+          right: "auto",
+          bottom: "auto",
+        };
+
+  const actionButtonClass =
+    "h-5 rounded px-1.5 text-[10px] font-medium border-white/20 bg-white/12 text-white hover:bg-white/22 hover:text-white";
+  const iconButtonClass =
+    "size-5 rounded-md border-white/20 bg-white/12 text-white hover:bg-white/22 hover:text-white";
+  const tabButtonClass = "rounded px-1.5 py-0.5 text-[10px] leading-none font-medium";
+
+  if (collapsed) {
+    return (
+      <div ref={containerRef} className="fixed bottom-3 right-3 z-50" style={floatingStyle}>
+        <button
+          type="button"
+          className="rounded-full border border-white/15 bg-neutral-950/92 px-2.5 py-1 text-[10px] font-medium text-white shadow-2xl backdrop-blur-md"
+          onPointerDown={beginDrag}
+          onPointerMove={onDragMove}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+          onClick={() => {
+            if (suppressClickRef.current) {
+              return;
+            }
+            setUserInputDebugCollapsed(false);
+          }}
+        >
+          Open Debug
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <aside
+      ref={containerRef}
+      className="fixed inset-x-2 bottom-2 z-50 max-h-[42vh] max-w-[calc(100vw-1rem)] overflow-hidden rounded-lg border border-white/12 bg-neutral-950/92 text-[11px] leading-tight text-white shadow-2xl backdrop-blur-md sm:right-4 sm:w-[24rem] sm:inset-x-auto"
+      style={floatingStyle}
+    >
+      <div className="flex items-start justify-between gap-1 border-b border-white/10 px-1.5 py-1">
+        <div
+          className="min-w-0 cursor-grab touch-none active:cursor-grabbing"
+          onPointerDown={beginDrag}
+          onPointerMove={onDragMove}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+        >
+          <p className="text-[10px] font-semibold tracking-[0.16em] text-white/55 uppercase">
+            User Input Debug
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center justify-end gap-1">
+          <div className="flex items-center rounded-md border border-white/10 bg-white/6 p-0.5">
+            <button
+              type="button"
+              className={cn(
+                tabButtonClass,
+                activeTab === "userInput"
+                  ? "bg-white/16 text-white"
+                  : "text-white/60 hover:text-white",
+              )}
+              onClick={() => setActiveTab("userInput")}
+            >
+              User Input
+            </button>
+            <button
+              type="button"
+              className={cn(
+                tabButtonClass,
+                activeTab === "crash" ? "bg-white/16 text-white" : "text-white/60 hover:text-white",
+              )}
+              onClick={() => setActiveTab("crash")}
+            >
+              Crash / OOM
+            </button>
+          </div>
+          <Button
+            size="icon-xs"
+            variant="outline"
+            className={iconButtonClass}
+            onClick={() => {
+              if (activeTab === "crash") {
+                clearCrashBreadcrumbs();
+                setSelectedCrashSession(null);
+                return;
+              }
+              clearUserInputDebugEntries();
+            }}
+            title={
+              activeTab === "crash" ? "Clear crash breadcrumbs" : "Clear user input breadcrumbs"
+            }
+            aria-label={
+              activeTab === "crash" ? "Clear crash breadcrumbs" : "Clear user input breadcrumbs"
+            }
+          >
+            <BrushCleaningIcon className="size-3" />
+          </Button>
+          <Button
+            size="icon-xs"
+            variant="outline"
+            className={iconButtonClass}
+            onClick={() => void copyLatestForTab()}
+            title={activeTab === "crash" ? "Copy latest crash breadcrumbs" : "Copy latest entries"}
+            aria-label={
+              activeTab === "crash" ? "Copy latest crash breadcrumbs" : "Copy latest entries"
+            }
+          >
+            {copied ? <CheckIcon className="size-3" /> : <CopyIcon className="size-3" />}
+          </Button>
+          {activeTab === "crash" ? (
+            <>
+              <Button
+                size="xs"
+                variant="outline"
+                className={actionButtonClass}
+                disabled={!previousCrashSession}
+                onClick={() => {
+                  const sessions = loadCrashBreadcrumbSessions();
+                  const previous = sessions[1] ?? null;
+                  setSelectedCrashSession(previous?.id ?? null);
+                }}
+              >
+                Prev Session
+              </Button>
+            </>
+          ) : null}
+          <Button
+            size="icon-xs"
+            variant="outline"
+            className={iconButtonClass}
+            onClick={() => setUserInputDebugCollapsed(true)}
+            title="Collapse debug panel"
+            aria-label="Collapse debug panel"
+          >
+            <ChevronsUpDownIcon className="size-3" />
+          </Button>
+          <Button
+            size="icon-xs"
+            variant="outline"
+            className={iconButtonClass}
+            onClick={() => setUserInputDebugEnabled(false)}
+            title="Close debug panel"
+            aria-label="Close debug panel"
+          >
+            <XIcon className="size-3" />
+          </Button>
+        </div>
+      </div>
+      <div className="max-h-[calc(42vh-2rem)] divide-y divide-white/8 overflow-y-auto">
+        {activeTab === "crash" ? (
+          renderedCrashEntries.length === 0 ? (
+            <div className="px-1.5 py-2 text-[10px] text-white/55">
+              No crash breadcrumbs captured yet.
+            </div>
+          ) : (
+            <>
+              {selectedCrashSession ? (
+                <section className="border-b border-white/8 bg-white/5 px-1.5 py-1.5 text-[10px] text-white/70">
+                  <p className="font-semibold text-white/85">
+                    Viewing session {selectedCrashSession.id}
+                  </p>
+                  <p className="mt-0.5">
+                    {formatSessionDisposition(selectedCrashSession.disposition)} · started{" "}
+                    {new Date(selectedCrashSession.startedAt).toLocaleTimeString([], {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                      second: "2-digit",
+                    })}
+                  </p>
+                </section>
+              ) : null}
+              {renderedCrashEntries.map((entry) => {
+                const detail = formatDetail(entry.detail);
+                return (
+                  <section key={entry.id} className={cn("px-1.5 py-1", toneClass(entry.level))}>
+                    <div className="flex items-start justify-between gap-1.5">
+                      <div className="min-w-0">
+                        <p className="text-[10px] font-semibold tracking-[0.14em] uppercase">
+                          {entry.stage}
+                        </p>
+                        <p className="mt-0.5 text-[11px] leading-snug">{entry.message}</p>
+                      </div>
+                      <time className="shrink-0 text-[9px] text-white/45">
+                        {new Date(entry.timestamp).toLocaleTimeString([], {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                          second: "2-digit",
+                        })}
+                      </time>
+                    </div>
+                    {entry.route ? (
+                      <p className="mt-0.5 text-[10px] text-white/55">route={entry.route}</p>
+                    ) : null}
+                    {detail ? (
+                      <pre className="mt-0.5 overflow-x-auto whitespace-pre-wrap break-words rounded bg-black/20 px-1 py-0.5 text-[9px] leading-snug text-white/72">
+                        {detail}
+                      </pre>
+                    ) : null}
+                  </section>
+                );
+              })}
+            </>
+          )
+        ) : renderedEntries.length === 0 ? (
+          <div className="px-1.5 py-2 text-[10px] text-white/55">Waiting for breadcrumbs...</div>
+        ) : (
+          renderedEntries.map((entry) => {
+            const detail = formatDetail(entry.detail);
+            return (
+              <section key={entry.id} className={cn("px-1.5 py-1", toneClass(entry.level))}>
+                <div className="flex items-start justify-between gap-1.5">
+                  <div className="min-w-0">
+                    <p className="text-[10px] font-semibold tracking-[0.14em] uppercase">
+                      {entry.stage}
+                    </p>
+                    <p className="mt-0.5 text-[11px] leading-snug">{entry.message}</p>
+                  </div>
+                  <time className="shrink-0 text-[9px] text-white/45">
+                    {new Date(entry.timestamp).toLocaleTimeString([], {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                      second: "2-digit",
+                    })}
+                  </time>
+                </div>
+                {entry.threadId || entry.requestId ? (
+                  <p className="mt-0.5 text-[10px] text-white/55">
+                    {entry.threadId ? `thread=${entry.threadId}` : null}
+                    {entry.threadId && entry.requestId ? " " : null}
+                    {entry.requestId ? `request=${entry.requestId}` : null}
+                  </p>
+                ) : null}
+                {detail ? (
+                  <pre className="mt-0.5 overflow-x-auto whitespace-pre-wrap break-words rounded bg-black/20 px-1 py-0.5 text-[9px] leading-snug text-white/72">
+                    {detail}
+                  </pre>
+                ) : null}
+              </section>
+            );
+          })
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/debug/UserInputDebugSidecar.tsx
+++ b/apps/web/src/debug/UserInputDebugSidecar.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+
+import { UserInputDebugPanel } from "../components/debug/UserInputDebugPanel";
+import { ensureCrashDebugSession, logCrashBreadcrumb } from "./crashDebug";
+import { logUserInputDebug } from "./userInputDebug";
+
+function withDetail(detail: string | undefined): { detail: string } | undefined {
+  return typeof detail === "string" ? { detail } : undefined;
+}
+
+export function UserInputDebugSidecar() {
+  useEffect(() => {
+    ensureCrashDebugSession();
+    logCrashBreadcrumb({
+      level: "info",
+      stage: "debug-panel-mounted",
+      message: "Fork debug panel sidecar mounted.",
+    });
+
+    const onError = (event: ErrorEvent) => {
+      logUserInputDebug({
+        level: "error",
+        stage: "window-error",
+        message: event.message || "Unhandled window error",
+        ...withDetail(
+          event.error instanceof Error
+            ? (event.error.stack ?? event.error.message)
+            : typeof event.error === "string"
+              ? event.error
+              : undefined,
+        ),
+      });
+    };
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason;
+      logUserInputDebug({
+        level: "error",
+        stage: "unhandled-rejection",
+        message:
+          reason instanceof Error
+            ? reason.message
+            : typeof reason === "string"
+              ? reason
+              : "Unhandled promise rejection",
+        ...withDetail(
+          reason instanceof Error
+            ? (reason.stack ?? reason.message)
+            : typeof reason === "string"
+              ? reason
+              : undefined,
+        ),
+      });
+    };
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onUnhandledRejection);
+    return () => {
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onUnhandledRejection);
+    };
+  }, []);
+
+  return <UserInputDebugPanel />;
+}

--- a/apps/web/src/debug/crashDebug.test.ts
+++ b/apps/web/src/debug/crashDebug.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+}
+
+const localStorage = new MemoryStorage();
+
+function installWindowStub() {
+  vi.stubGlobal("window", {
+    localStorage,
+    location: {
+      pathname: "/thread/test",
+      search: "?foo=bar",
+      hash: "#frag",
+    },
+  });
+}
+
+async function loadCrashDebugModule() {
+  vi.resetModules();
+  return import("./crashDebug");
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  installWindowStub();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("crashDebug", () => {
+  it("starts a new session and infers the previous active session crashed on next bootstrap", async () => {
+    const first = await loadCrashDebugModule();
+    const firstSessionId = first.initializeCrashDebugSession();
+    first.logCrashBreadcrumb({
+      level: "info",
+      stage: "snapshot-sync-start",
+      message: "Fetching snapshot",
+    });
+
+    const second = await loadCrashDebugModule();
+    const secondSessionId = second.initializeCrashDebugSession();
+
+    expect(firstSessionId).not.toBeNull();
+    expect(secondSessionId).not.toBeNull();
+
+    const sessions = second.loadCrashBreadcrumbSessions();
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0]?.id).toBe(secondSessionId);
+    expect(sessions[1]?.id).toBe(firstSessionId);
+    expect(sessions[1]?.disposition).toBe("possible-renderer-crash");
+    expect(sessions[1]?.breadcrumbs.some((entry) => entry.stage === "session-inferred-crash")).toBe(
+      true,
+    );
+  });
+
+  it("formats a compact crash report with snapshot and domain event summaries", async () => {
+    const crashDebug = await loadCrashDebugModule();
+    crashDebug.initializeCrashDebugSession();
+    crashDebug.logCrashBreadcrumb({
+      level: "info",
+      stage: "domain-event",
+      message: "Observed thread.turn-diff-completed.",
+      detail: JSON.stringify({ sequence: 42 }),
+    });
+    crashDebug.logCrashBreadcrumb({
+      level: "info",
+      stage: "snapshot-sync-complete",
+      message: "Applied orchestration snapshot 9.",
+      detail: crashDebug.formatCrashSnapshotSummary({
+        snapshotSequence: 9,
+        projectCount: 1,
+        threadCount: 2,
+        totalMessageCount: 11,
+        totalCheckpointCount: 4,
+        totalActivityCount: 6,
+        currentRoute: "/thread/test",
+      }),
+    });
+
+    const report = crashDebug.buildCrashBreadcrumbReport();
+
+    expect(report).toContain("Selected session disposition: active");
+    expect(report).toContain("Latest snapshot summary:");
+    expect(report).toContain('"snapshotSequence": 9');
+    expect(report).toContain("Latest domain event:");
+    expect(report).toContain("Observed thread.turn-diff-completed.");
+  });
+
+  it("clears breadcrumbs without dropping the active session", async () => {
+    const crashDebug = await loadCrashDebugModule();
+    const sessionId = crashDebug.initializeCrashDebugSession();
+    crashDebug.logCrashBreadcrumb({
+      level: "error",
+      stage: "window-error",
+      message: "Boom",
+    });
+
+    crashDebug.clearCrashBreadcrumbs();
+    crashDebug.logCrashBreadcrumb({
+      level: "info",
+      stage: "page-show",
+      message: "Page shown.",
+    });
+
+    const sessions = crashDebug.loadCrashBreadcrumbSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.id).toBe(sessionId);
+    expect(sessions[0]?.breadcrumbs).toHaveLength(1);
+    expect(sessions[0]?.breadcrumbs[0]?.stage).toBe("page-show");
+  });
+});

--- a/apps/web/src/debug/crashDebug.ts
+++ b/apps/web/src/debug/crashDebug.ts
@@ -1,0 +1,535 @@
+import { create } from "zustand";
+
+const CRASH_DEBUG_STORAGE_KEY = "t3code:debug-crash-breadcrumbs";
+let crashDebugSessionInitialized = false;
+const MAX_CRASH_SESSIONS = 3;
+const MAX_CRASH_BREADCRUMBS = 120;
+const MAX_MESSAGE_CHARS = 240;
+const MAX_DETAIL_CHARS = 1_500;
+const MAX_COPY_BREADCRUMBS = 40;
+
+type CrashBreadcrumbLevel = "info" | "warning" | "error";
+export type CrashSessionDisposition =
+  | "active"
+  | "clean-exit"
+  | "root-error"
+  | "possible-renderer-crash";
+
+export interface CrashBreadcrumbEntry {
+  id: string;
+  timestamp: string;
+  level: CrashBreadcrumbLevel;
+  stage: string;
+  message: string;
+  route?: string;
+  detail?: string;
+}
+
+export interface CrashBreadcrumbSession {
+  id: string;
+  startedAt: string;
+  updatedAt: string;
+  disposition: CrashSessionDisposition;
+  breadcrumbs: CrashBreadcrumbEntry[];
+}
+
+interface CrashDebugEnvelope {
+  currentSessionId: string | null;
+  sessions: CrashBreadcrumbSession[];
+}
+
+interface CrashDebugState {
+  sessions: CrashBreadcrumbSession[];
+  selectedSessionId: string | null;
+  setSessions: (sessions: CrashBreadcrumbSession[]) => void;
+  setSelectedSessionId: (sessionId: string | null) => void;
+}
+
+interface PersistedCrashBreadcrumbInput {
+  readonly level: CrashBreadcrumbLevel;
+  readonly stage: string;
+  readonly message: string;
+  readonly route?: string | undefined;
+  readonly detail?: string | undefined;
+}
+
+interface SnapshotSummaryInput {
+  readonly snapshotSequence: number;
+  readonly projectCount: number;
+  readonly threadCount: number;
+  readonly totalMessageCount: number;
+  readonly totalCheckpointCount: number;
+  readonly totalActivityCount: number;
+  readonly currentRoute?: string | undefined;
+}
+
+const initialCrashEnvelope = readCrashDebugEnvelope();
+
+export const useCrashDebugStore = create<CrashDebugState>((set) => ({
+  sessions: initialCrashEnvelope.sessions,
+  selectedSessionId: initialCrashEnvelope.currentSessionId,
+  setSessions: (sessions) => set({ sessions }),
+  setSelectedSessionId: (selectedSessionId) => set({ selectedSessionId }),
+}));
+
+function nextDebugId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `crash-debug-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function truncateText(value: string, maxChars: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, maxChars - 16)}...[truncated]`;
+}
+
+function resolveCurrentRoute(): string {
+  if (typeof window === "undefined") {
+    return "/";
+  }
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function currentHeapSummary(): string | undefined {
+  if (typeof performance === "undefined") {
+    return undefined;
+  }
+  const candidate = performance as Performance & {
+    memory?: {
+      usedJSHeapSize?: number;
+      totalJSHeapSize?: number;
+      jsHeapSizeLimit?: number;
+    };
+  };
+  if (!candidate.memory) {
+    return undefined;
+  }
+
+  const { usedJSHeapSize, totalJSHeapSize, jsHeapSizeLimit } = candidate.memory;
+  const values = [
+    typeof usedJSHeapSize === "number" ? `used=${usedJSHeapSize}` : null,
+    typeof totalJSHeapSize === "number" ? `total=${totalJSHeapSize}` : null,
+    typeof jsHeapSizeLimit === "number" ? `limit=${jsHeapSizeLimit}` : null,
+  ].filter(Boolean);
+
+  return values.length > 0 ? values.join(" ") : undefined;
+}
+
+function readCrashDebugEnvelope(): CrashDebugEnvelope {
+  if (typeof window === "undefined") {
+    return {
+      currentSessionId: null,
+      sessions: [],
+    };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(CRASH_DEBUG_STORAGE_KEY);
+    if (!raw) {
+      return {
+        currentSessionId: null,
+        sessions: [],
+      };
+    }
+    const parsed = JSON.parse(raw) as {
+      currentSessionId?: unknown;
+      sessions?: Array<{
+        id?: unknown;
+        startedAt?: unknown;
+        updatedAt?: unknown;
+        disposition?: unknown;
+        breadcrumbs?: Array<{
+          id?: unknown;
+          timestamp?: unknown;
+          level?: unknown;
+          stage?: unknown;
+          message?: unknown;
+          route?: unknown;
+          detail?: unknown;
+        }>;
+      }>;
+    };
+    const sessions = Array.isArray(parsed.sessions)
+      ? parsed.sessions
+          .map((session): CrashBreadcrumbSession | null => {
+            if (
+              typeof session?.id !== "string" ||
+              typeof session.startedAt !== "string" ||
+              typeof session.updatedAt !== "string"
+            ) {
+              return null;
+            }
+            const disposition =
+              session.disposition === "active" ||
+              session.disposition === "clean-exit" ||
+              session.disposition === "root-error" ||
+              session.disposition === "possible-renderer-crash"
+                ? session.disposition
+                : "active";
+            const breadcrumbs = Array.isArray(session.breadcrumbs)
+              ? session.breadcrumbs
+                  .map((entry): CrashBreadcrumbEntry | null => {
+                    if (
+                      typeof entry?.id !== "string" ||
+                      typeof entry.timestamp !== "string" ||
+                      typeof entry.level !== "string" ||
+                      typeof entry.stage !== "string" ||
+                      typeof entry.message !== "string"
+                    ) {
+                      return null;
+                    }
+                    return {
+                      id: entry.id,
+                      timestamp: entry.timestamp,
+                      level:
+                        entry.level === "warning" || entry.level === "error" ? entry.level : "info",
+                      stage: entry.stage,
+                      message: entry.message,
+                      ...(typeof entry.route === "string" ? { route: entry.route } : {}),
+                      ...(typeof entry.detail === "string" ? { detail: entry.detail } : {}),
+                    };
+                  })
+                  .filter((entry): entry is CrashBreadcrumbEntry => entry !== null)
+              : [];
+            return {
+              id: session.id,
+              startedAt: session.startedAt,
+              updatedAt: session.updatedAt,
+              disposition,
+              breadcrumbs,
+            };
+          })
+          .filter((session): session is CrashBreadcrumbSession => session !== null)
+      : [];
+
+    return {
+      currentSessionId:
+        typeof parsed.currentSessionId === "string" ? parsed.currentSessionId : null,
+      sessions,
+    };
+  } catch {
+    return {
+      currentSessionId: null,
+      sessions: [],
+    };
+  }
+}
+
+function persistCrashDebugEnvelope(envelope: CrashDebugEnvelope): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(CRASH_DEBUG_STORAGE_KEY, JSON.stringify(envelope));
+  } catch {
+    // Ignore storage failures to avoid destabilizing the app during OOM pressure.
+  }
+}
+
+function syncCrashDebugStore(envelope: CrashDebugEnvelope): void {
+  const state = useCrashDebugStore.getState();
+  state.setSessions(envelope.sessions);
+  const selectedSessionStillExists =
+    state.selectedSessionId !== null &&
+    envelope.sessions.some((session) => session.id === state.selectedSessionId);
+
+  if (selectedSessionStillExists) {
+    return;
+  }
+
+  state.setSelectedSessionId(envelope.currentSessionId ?? envelope.sessions[0]?.id ?? null);
+}
+
+function updateCrashDebugEnvelope(
+  updater: (envelope: CrashDebugEnvelope) => CrashDebugEnvelope,
+): CrashDebugEnvelope {
+  const nextEnvelope = updater(readCrashDebugEnvelope());
+  persistCrashDebugEnvelope(nextEnvelope);
+  syncCrashDebugStore(nextEnvelope);
+  return nextEnvelope;
+}
+
+function withCurrentSession(envelope: CrashDebugEnvelope): {
+  envelope: CrashDebugEnvelope;
+  session: CrashBreadcrumbSession | null;
+} {
+  const session = envelope.currentSessionId
+    ? (envelope.sessions.find((candidate) => candidate.id === envelope.currentSessionId) ?? null)
+    : null;
+  return { envelope, session };
+}
+
+function appendBreadcrumb(
+  session: CrashBreadcrumbSession,
+  input: PersistedCrashBreadcrumbInput,
+): CrashBreadcrumbSession {
+  const timestamp = new Date().toISOString();
+  const entry: CrashBreadcrumbEntry = {
+    id: nextDebugId(),
+    timestamp,
+    level: input.level,
+    stage: truncateText(input.stage, 80),
+    message: truncateText(input.message, MAX_MESSAGE_CHARS),
+    route: truncateText(input.route ?? resolveCurrentRoute(), 200),
+    ...(input.detail ? { detail: truncateText(input.detail, MAX_DETAIL_CHARS) } : {}),
+  };
+  const nextBreadcrumbs = [...session.breadcrumbs, entry];
+
+  return {
+    ...session,
+    updatedAt: timestamp,
+    breadcrumbs:
+      nextBreadcrumbs.length > MAX_CRASH_BREADCRUMBS
+        ? nextBreadcrumbs.slice(nextBreadcrumbs.length - MAX_CRASH_BREADCRUMBS)
+        : nextBreadcrumbs,
+  };
+}
+
+function inferCrashBreadcrumb(): PersistedCrashBreadcrumbInput {
+  const detail = currentHeapSummary();
+  return {
+    level: "warning",
+    stage: "session-inferred-crash",
+    message: "Previous crash debug session ended without a clean exit marker.",
+    ...(detail ? { detail } : {}),
+  };
+}
+
+export function initializeCrashDebugSession(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const nextSessionId = nextDebugId();
+  const timestamp = new Date().toISOString();
+  const initialHeapSummary = currentHeapSummary();
+
+  const nextEnvelope = updateCrashDebugEnvelope((envelope) => {
+    const sessions = envelope.sessions.map((session) => {
+      if (session.id !== envelope.currentSessionId || session.disposition !== "active") {
+        return session;
+      }
+
+      return appendBreadcrumb(
+        {
+          ...session,
+          disposition: "possible-renderer-crash",
+          updatedAt: timestamp,
+        },
+        inferCrashBreadcrumb(),
+      );
+    });
+
+    const nextSession: CrashBreadcrumbSession = {
+      id: nextSessionId,
+      startedAt: timestamp,
+      updatedAt: timestamp,
+      disposition: "active",
+      breadcrumbs: [
+        {
+          id: nextDebugId(),
+          timestamp,
+          level: "info",
+          stage: "session-start",
+          message: "Crash debug session started.",
+          route: resolveCurrentRoute(),
+          ...(initialHeapSummary ? { detail: initialHeapSummary } : {}),
+        },
+      ],
+    };
+
+    return {
+      currentSessionId: nextSessionId,
+      sessions: [nextSession, ...sessions].slice(0, MAX_CRASH_SESSIONS),
+    };
+  });
+
+  return nextEnvelope.currentSessionId;
+}
+
+export function ensureCrashDebugSession(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  if (crashDebugSessionInitialized) {
+    return readCrashDebugEnvelope().currentSessionId;
+  }
+
+  const nextSessionId = initializeCrashDebugSession();
+  crashDebugSessionInitialized = nextSessionId !== null;
+  return nextSessionId;
+}
+
+export function logCrashBreadcrumb(entry: PersistedCrashBreadcrumbInput): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  updateCrashDebugEnvelope((envelope) => {
+    const { session } = withCurrentSession(envelope);
+    if (!session) {
+      return envelope;
+    }
+
+    return {
+      ...envelope,
+      sessions: envelope.sessions.map((candidate) =>
+        candidate.id === session.id ? appendBreadcrumb(candidate, entry) : candidate,
+      ),
+    };
+  });
+}
+
+export function logCrashBreadcrumbLazy(factory: () => PersistedCrashBreadcrumbInput): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (readCrashDebugEnvelope().currentSessionId === null) {
+    return;
+  }
+  logCrashBreadcrumb(factory());
+}
+
+export function setCrashSessionDisposition(
+  disposition: Exclude<CrashSessionDisposition, "active">,
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (disposition === "clean-exit") {
+    crashDebugSessionInitialized = false;
+  }
+
+  updateCrashDebugEnvelope((envelope) => {
+    const { session } = withCurrentSession(envelope);
+    if (!session || session.disposition === disposition) {
+      return envelope;
+    }
+
+    return {
+      ...envelope,
+      currentSessionId: disposition === "clean-exit" ? null : envelope.currentSessionId,
+      sessions: envelope.sessions.map((candidate) =>
+        candidate.id === session.id
+          ? {
+              ...candidate,
+              disposition,
+              updatedAt: new Date().toISOString(),
+            }
+          : candidate,
+      ),
+    };
+  });
+}
+
+export function clearCrashBreadcrumbs(): void {
+  updateCrashDebugEnvelope((envelope) => {
+    const { session } = withCurrentSession(envelope);
+    if (!session) {
+      return envelope;
+    }
+
+    const clearedSession: CrashBreadcrumbSession = {
+      ...session,
+      updatedAt: new Date().toISOString(),
+      breadcrumbs: [],
+    };
+
+    return {
+      ...envelope,
+      sessions: envelope.sessions.map((candidate) =>
+        candidate.id === clearedSession.id ? clearedSession : candidate,
+      ),
+    };
+  });
+}
+
+export function loadCrashBreadcrumbSessions(): CrashBreadcrumbSession[] {
+  return readCrashDebugEnvelope().sessions;
+}
+
+export function setSelectedCrashSession(sessionId: string | null): void {
+  useCrashDebugStore.getState().setSelectedSessionId(sessionId);
+}
+
+export function formatCrashSnapshotSummary(input: SnapshotSummaryInput): string {
+  const values = {
+    snapshotSequence: input.snapshotSequence,
+    projectCount: input.projectCount,
+    threadCount: input.threadCount,
+    totalMessageCount: input.totalMessageCount,
+    totalCheckpointCount: input.totalCheckpointCount,
+    totalActivityCount: input.totalActivityCount,
+    ...(input.currentRoute ? { currentRoute: input.currentRoute } : {}),
+    ...(currentHeapSummary() ? { heap: currentHeapSummary() } : {}),
+  };
+  return JSON.stringify(values, null, 2);
+}
+
+export function buildCrashBreadcrumbReport(sessionId?: string | null): string {
+  const envelope = readCrashDebugEnvelope();
+  const targetSession =
+    (sessionId ? envelope.sessions.find((session) => session.id === sessionId) : null) ??
+    (envelope.currentSessionId
+      ? envelope.sessions.find((session) => session.id === envelope.currentSessionId)
+      : null) ??
+    envelope.sessions[0] ??
+    null;
+
+  if (!targetSession) {
+    return "No crash breadcrumbs captured yet.";
+  }
+
+  const latestSnapshotBreadcrumb =
+    targetSession.breadcrumbs
+      .toReversed()
+      .find(
+        (entry) =>
+          entry.stage === "snapshot-sync-complete" || entry.stage === "snapshot-sync-failed",
+      ) ?? null;
+  const latestDomainEvent =
+    targetSession.breadcrumbs.toReversed().find((entry) => entry.stage === "domain-event") ?? null;
+
+  const lines = [
+    `Generated: ${new Date().toISOString()}`,
+    `Selected session: ${targetSession.id}`,
+    `Selected session disposition: ${targetSession.disposition}`,
+    `Selected session started: ${targetSession.startedAt}`,
+    `Selected session updated: ${targetSession.updatedAt}`,
+    `Current session id: ${envelope.currentSessionId ?? "none"}`,
+    `Current route: ${resolveCurrentRoute()}`,
+    currentHeapSummary() ? `Heap: ${currentHeapSummary()}` : null,
+    "",
+    "Latest snapshot summary:",
+    latestSnapshotBreadcrumb?.detail ?? "No snapshot summary captured.",
+    "",
+    "Latest domain event:",
+    latestDomainEvent
+      ? `${latestDomainEvent.timestamp} | ${latestDomainEvent.message}${latestDomainEvent.detail ? ` | ${latestDomainEvent.detail}` : ""}`
+      : "No domain event breadcrumb captured.",
+    "",
+    "Recent crash breadcrumbs:",
+    ...targetSession.breadcrumbs
+      .slice(-MAX_COPY_BREADCRUMBS)
+      .map((entry) =>
+        [
+          entry.timestamp,
+          entry.level.toUpperCase(),
+          entry.stage,
+          entry.message,
+          entry.route ? `route=${entry.route}` : null,
+          entry.detail ? `detail=${entry.detail}` : null,
+        ]
+          .filter(Boolean)
+          .join(" | "),
+      ),
+  ];
+
+  return lines.filter((line): line is string => line !== null).join("\n");
+}

--- a/apps/web/src/debug/userInputDebug.ts
+++ b/apps/web/src/debug/userInputDebug.ts
@@ -1,0 +1,255 @@
+import { create } from "zustand";
+
+const USER_INPUT_DEBUG_QUERY_PARAM = "debugUserInput";
+const USER_INPUT_DEBUG_STORAGE_KEY = "t3code:debug-user-input";
+const MAX_DEBUG_ENTRIES = 200;
+
+type UserInputDebugLevel = "info" | "success" | "warning" | "error";
+
+export interface UserInputDebugEntry {
+  id: string;
+  timestamp: string;
+  level: UserInputDebugLevel;
+  stage: string;
+  message: string;
+  threadId?: string | null;
+  requestId?: string | null;
+  detail?: string;
+}
+
+interface UserInputDebugState {
+  enabled: boolean;
+  collapsed: boolean;
+  position: { x: number; y: number } | null;
+  entries: UserInputDebugEntry[];
+  setEnabled: (enabled: boolean) => void;
+  setCollapsed: (collapsed: boolean) => void;
+  setPosition: (position: { x: number; y: number } | null) => void;
+  pushEntry: (entry: Omit<UserInputDebugEntry, "id" | "timestamp">) => void;
+  clear: () => void;
+}
+
+function readSearchParamEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const value = new URLSearchParams(window.location.search).get(USER_INPUT_DEBUG_QUERY_PARAM);
+  return value === "1" || value === "true" || value === "on";
+}
+
+function canPersistDebugState(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const hostname = window.location.hostname.toLowerCase();
+  return (
+    hostname === "t3-dev.claude.do" ||
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1"
+  );
+}
+
+function readPersistedEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    const raw = window.localStorage.getItem(USER_INPUT_DEBUG_STORAGE_KEY);
+    if (!raw) {
+      return false;
+    }
+    if (raw === "1") {
+      return true;
+    }
+    const parsed = JSON.parse(raw) as { enabled?: boolean };
+    return parsed.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+function readPersistedLayout(): {
+  collapsed: boolean;
+  position: { x: number; y: number } | null;
+} {
+  if (typeof window === "undefined") {
+    return { collapsed: false, position: null };
+  }
+  try {
+    const raw = window.localStorage.getItem(USER_INPUT_DEBUG_STORAGE_KEY);
+    if (!raw || raw === "1") {
+      return { collapsed: false, position: null };
+    }
+    const parsed = JSON.parse(raw) as {
+      collapsed?: boolean;
+      position?: { x?: number; y?: number } | null;
+    };
+    return {
+      collapsed: parsed.collapsed === true,
+      position:
+        parsed.position &&
+        typeof parsed.position.x === "number" &&
+        typeof parsed.position.y === "number"
+          ? { x: parsed.position.x, y: parsed.position.y }
+          : null,
+    };
+  } catch {
+    return { collapsed: false, position: null };
+  }
+}
+
+function persistDebugState(input: {
+  enabled: boolean;
+  collapsed: boolean;
+  position: { x: number; y: number } | null;
+}): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    if (!canPersistDebugState()) {
+      window.localStorage.removeItem(USER_INPUT_DEBUG_STORAGE_KEY);
+      return;
+    }
+    if (input.enabled) {
+      window.localStorage.setItem(
+        USER_INPUT_DEBUG_STORAGE_KEY,
+        JSON.stringify({
+          enabled: true,
+          collapsed: input.collapsed,
+          position: input.position,
+        }),
+      );
+      return;
+    }
+    window.localStorage.removeItem(USER_INPUT_DEBUG_STORAGE_KEY);
+  } catch {
+    // Ignore storage write failures in debug mode.
+  }
+}
+
+function resolveInitialEnabled(): boolean {
+  const enabled = readSearchParamEnabled() || (canPersistDebugState() && readPersistedEnabled());
+  if (enabled) {
+    const layout = readPersistedLayout();
+    persistDebugState({
+      enabled: true,
+      collapsed: layout.collapsed,
+      position: layout.position,
+    });
+  }
+  return enabled;
+}
+
+function nextDebugId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `user-input-debug-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+const initialEnabled = resolveInitialEnabled();
+const initialLayout = readPersistedLayout();
+
+export const useUserInputDebugStore = create<UserInputDebugState>((set) => ({
+  enabled: initialEnabled,
+  collapsed: initialLayout.collapsed,
+  position: initialLayout.position,
+  entries: [],
+  setEnabled: (enabled) => {
+    set((state) => {
+      persistDebugState({
+        enabled,
+        collapsed: enabled ? state.collapsed : false,
+        position: enabled ? state.position : null,
+      });
+      return {
+        enabled,
+        collapsed: enabled ? state.collapsed : false,
+        position: enabled ? state.position : null,
+      };
+    });
+  },
+  setCollapsed: (collapsed) => {
+    set((state) => {
+      persistDebugState({
+        enabled: state.enabled,
+        collapsed,
+        position: state.position,
+      });
+      return { collapsed };
+    });
+  },
+  setPosition: (position) => {
+    set((state) => {
+      persistDebugState({
+        enabled: state.enabled,
+        collapsed: state.collapsed,
+        position,
+      });
+      return { position };
+    });
+  },
+  pushEntry: (entry) =>
+    set((state) => {
+      if (!state.enabled) {
+        return state;
+      }
+      const nextEntry: UserInputDebugEntry = {
+        ...entry,
+        id: nextDebugId(),
+        timestamp: new Date().toISOString(),
+      };
+      const nextEntries = [...state.entries, nextEntry];
+      return {
+        entries:
+          nextEntries.length > MAX_DEBUG_ENTRIES
+            ? nextEntries.slice(nextEntries.length - MAX_DEBUG_ENTRIES)
+            : nextEntries,
+      };
+    }),
+  clear: () => set({ entries: [] }),
+}));
+
+export function logUserInputDebug(entry: Omit<UserInputDebugEntry, "id" | "timestamp">): void {
+  const store = useUserInputDebugStore.getState();
+  if (!store.enabled) {
+    return;
+  }
+  store.pushEntry(entry);
+  console.debug("[user-input-debug]", entry);
+}
+
+export function logUserInputDebugLazy(
+  factory: () => Omit<UserInputDebugEntry, "id" | "timestamp">,
+): void {
+  const store = useUserInputDebugStore.getState();
+  if (!store.enabled) {
+    return;
+  }
+
+  const entry = factory();
+  store.pushEntry(entry);
+  console.debug("[user-input-debug]", entry);
+}
+
+export function setUserInputDebugEnabled(enabled: boolean): void {
+  useUserInputDebugStore.getState().setEnabled(enabled);
+}
+
+export function setUserInputDebugCollapsed(collapsed: boolean): void {
+  useUserInputDebugStore.getState().setCollapsed(collapsed);
+}
+
+export function setUserInputDebugPosition(position: { x: number; y: number } | null): void {
+  useUserInputDebugStore.getState().setPosition(position);
+}
+
+export function clearUserInputDebugEntries(): void {
+  useUserInputDebugStore.getState().clear();
+}
+
+export function isUserInputDebugEnabled(): boolean {
+  return useUserInputDebugStore.getState().enabled;
+}

--- a/apps/web/src/environments/runtime/service.ts
+++ b/apps/web/src/environments/runtime/service.ts
@@ -26,6 +26,9 @@ import {
 import { ensureLocalApi } from "~/localApi";
 import { collectActiveTerminalThreadIds } from "~/lib/terminalStateCleanup";
 import { deriveOrchestrationBatchEffects } from "~/orchestrationEventEffects";
+import { toastManager } from "~/components/ui/toast";
+import { logCrashBreadcrumbLazy } from "~/debug/crashDebug";
+import { describePendingUserInputFailure, logForkDebugEvent } from "~/fork/bootstrap/rootDebug";
 import { projectQueryKeys } from "~/lib/projectReactQuery";
 import { providerQueryKeys } from "~/lib/providerReactQuery";
 import { getPrimaryKnownEnvironment } from "../primary";
@@ -641,6 +644,33 @@ function applyRecoveredEventBatch(
   if (batchEffects.needsProviderInvalidation) {
     needsProviderInvalidation = true;
     void activeService?.queryInvalidationThrottler.maybeExecute();
+  }
+
+  for (const event of events) {
+    logForkDebugEvent(event);
+    logCrashBreadcrumbLazy(() => ({
+      level: "info",
+      stage: "domain-event",
+      message: `Observed ${event.type}.`,
+      route: window.location.pathname,
+      detail: JSON.stringify({
+        sequence: event.sequence,
+        ...(typeof (event.payload as { threadId?: unknown }).threadId === "string"
+          ? { threadId: (event.payload as { threadId: string }).threadId }
+          : {}),
+      }),
+    }));
+
+    if (
+      event.type === "thread.activity-appended" &&
+      event.payload.activity.kind === "provider.user-input.respond.failed"
+    ) {
+      toastManager.add({
+        type: "warning",
+        title: "Question expired",
+        description: describePendingUserInputFailure(event.payload.activity),
+      });
+    }
   }
 
   useStore.getState().applyOrchestrationEvents(uiEvents, environmentId);

--- a/apps/web/src/fork/bootstrap/ForkRootSidecars.tsx
+++ b/apps/web/src/fork/bootstrap/ForkRootSidecars.tsx
@@ -1,0 +1,5 @@
+import { UserInputDebugSidecar } from "../../debug/UserInputDebugSidecar";
+
+export function ForkRootSidecars() {
+  return <UserInputDebugSidecar />;
+}

--- a/apps/web/src/fork/bootstrap/index.ts
+++ b/apps/web/src/fork/bootstrap/index.ts
@@ -1,1 +1,2 @@
 export { installForkWebShell } from "./installForkWebShell";
+export { ForkRootSidecars } from "./ForkRootSidecars";

--- a/apps/web/src/fork/bootstrap/rootDebug.test.ts
+++ b/apps/web/src/fork/bootstrap/rootDebug.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { logUserInputDebugLazy } = vi.hoisted(() => ({
+  logUserInputDebugLazy: vi.fn(),
+}));
+
+vi.mock("../../debug/userInputDebug", () => ({
+  logUserInputDebugLazy,
+}));
+
+import { describePendingUserInputFailure, logForkDebugEvent } from "./rootDebug";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("describePendingUserInputFailure", () => {
+  it("prefers a trimmed payload detail when present", () => {
+    expect(
+      describePendingUserInputFailure({
+        kind: "provider.user-input.respond.failed",
+        summary: "failed",
+        payload: {
+          detail: "  Server said no  ",
+        },
+      } as never),
+    ).toBe("Server said no");
+  });
+
+  it("falls back to the default recovery message", () => {
+    expect(
+      describePendingUserInputFailure({
+        kind: "provider.user-input.respond.failed",
+        summary: "failed",
+        payload: {},
+      } as never),
+    ).toContain("Please ask the agent again");
+  });
+});
+
+describe("logForkDebugEvent", () => {
+  it("records user-input response requests", () => {
+    logForkDebugEvent({
+      type: "thread.user-input-response-requested",
+      payload: {
+        threadId: "thread-1",
+        requestId: "req-1",
+        answers: [{ text: "hello" }],
+      },
+    } as never);
+
+    expect(logUserInputDebugLazy).toHaveBeenCalledOnce();
+  });
+
+  it("records interesting thread activities", () => {
+    logForkDebugEvent({
+      type: "thread.activity-appended",
+      payload: {
+        threadId: "thread-1",
+        activity: {
+          kind: "provider.user-input.respond.failed",
+          summary: "failed",
+          payload: {
+            requestId: "req-2",
+            detail: "boom",
+          },
+        },
+      },
+    } as never);
+
+    expect(logUserInputDebugLazy).toHaveBeenCalledOnce();
+  });
+
+  it("ignores unrelated domain events", () => {
+    logForkDebugEvent({
+      type: "thread.completed",
+      payload: {
+        threadId: "thread-1",
+      },
+    } as never);
+
+    expect(logUserInputDebugLazy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/fork/bootstrap/rootDebug.ts
+++ b/apps/web/src/fork/bootstrap/rootDebug.ts
@@ -1,0 +1,84 @@
+import { type OrchestrationEvent, type OrchestrationThreadActivity } from "@t3tools/contracts";
+
+import { logUserInputDebugLazy } from "../../debug/userInputDebug";
+
+export function logForkDebugEvent(event: OrchestrationEvent): void {
+  if (event.type === "thread.user-input-response-requested") {
+    logUserInputDebugLazy(() => ({
+      level: "info",
+      stage: "domain-event",
+      message: "Observed thread.user-input-response-requested",
+      threadId: event.payload.threadId,
+      requestId: event.payload.requestId,
+      ...withDebugDetail(stringifyDebugDetail(event.payload.answers)),
+    }));
+    return;
+  }
+
+  if (event.type !== "thread.activity-appended") {
+    return;
+  }
+
+  const activity = event.payload.activity;
+  if (!isInterestingUserInputActivity(activity)) {
+    return;
+  }
+
+  logUserInputDebugLazy(() => ({
+    level: activity.kind === "provider.user-input.respond.failed" ? "error" : "success",
+    stage: "domain-activity",
+    message: `Observed ${activity.kind}`,
+    threadId: event.payload.threadId,
+    requestId: requestIdFromActivity(activity),
+    ...withDebugDetail(
+      stringifyDebugDetail({
+        summary: activity.summary,
+        payload: activity.payload,
+      }),
+    ),
+  }));
+}
+
+export function describePendingUserInputFailure(activity: OrchestrationThreadActivity): string {
+  const payload =
+    activity.payload && typeof activity.payload === "object"
+      ? (activity.payload as Record<string, unknown>)
+      : null;
+  const detail = payload && typeof payload.detail === "string" ? payload.detail.trim() : "";
+  if (detail.length > 0) {
+    return detail;
+  }
+  return "The pending question expired or no longer exists. Please ask the agent again if you still need to respond.";
+}
+
+function isInterestingUserInputActivity(activity: OrchestrationThreadActivity): boolean {
+  return (
+    activity.kind === "user-input.requested" ||
+    activity.kind === "user-input.resolved" ||
+    activity.kind === "provider.user-input.respond.failed"
+  );
+}
+
+function requestIdFromActivity(activity: OrchestrationThreadActivity): string | null {
+  const payload = activity.payload;
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const requestId = (payload as Record<string, unknown>).requestId;
+  return typeof requestId === "string" ? requestId : null;
+}
+
+function stringifyDebugDetail(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function withDebugDetail(detail: string | undefined): { detail: string } | undefined {
+  return typeof detail === "string" ? { detail } : undefined;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -54,6 +54,12 @@ import {
   resolveInitialServerAuthGateState,
   updatePrimaryEnvironmentDescriptor,
 } from "../environments/primary";
+import { ForkRootSidecars } from "../fork/bootstrap";
+import {
+  ensureCrashDebugSession,
+  logCrashBreadcrumb,
+  setCrashSessionDisposition,
+} from "../debug/crashDebug";
 import { useNotificationNavigation } from "../notifications/useNotificationNavigation";
 
 export const Route = createRootRouteWithContext<{
@@ -81,6 +87,32 @@ function RootRouteView() {
   const { authGateState } = Route.useRouteContext();
 
   useEffect(() => {
+    ensureCrashDebugSession();
+  }, []);
+
+  useEffect(() => {
+    const onPageShow = () => {
+      ensureCrashDebugSession();
+    };
+    const onPageHide = () => {
+      setCrashSessionDisposition("clean-exit");
+    };
+
+    window.addEventListener("pageshow", onPageShow);
+    window.addEventListener("pagehide", onPageHide);
+    return () => {
+      window.removeEventListener("pageshow", onPageShow);
+      window.removeEventListener("pagehide", onPageHide);
+    };
+  }, []);
+
+  useEffect(() => {
+    logCrashBreadcrumb({
+      level: "info",
+      stage: "route-change",
+      message: `Navigated to ${pathname}`,
+      route: pathname,
+    });
     const frame = window.requestAnimationFrame(() => {
       syncBrowserChromeTheme();
     });
@@ -103,6 +135,7 @@ function RootRouteView() {
         <ServerStateBootstrap />
         <EnvironmentConnectionManagerBootstrap />
         <EventRouter />
+        <ForkRootSidecars />
         <WebSocketConnectionCoordinator />
         <SlowRpcAckToastCoordinator />
         <WebSocketConnectionSurface>
@@ -118,6 +151,18 @@ function RootRouteView() {
 }
 
 function RootRouteErrorView({ error, reset }: ErrorComponentProps) {
+  useEffect(() => {
+    ensureCrashDebugSession();
+    logCrashBreadcrumb({
+      level: "error",
+      stage: "root-route-error",
+      message: errorMessage(error),
+      detail: errorDetails(error),
+      route: window.location.pathname,
+    });
+    setCrashSessionDisposition("root-error");
+  }, [error]);
+
   const message = errorMessage(error);
   const details = errorDetails(error);
 

--- a/apps/web/src/settings/ForkSettingsSection.browser.tsx
+++ b/apps/web/src/settings/ForkSettingsSection.browser.tsx
@@ -18,11 +18,54 @@ const mockedForkSettingsModule = vi.hoisted(() => ({
   },
 }));
 
+const mockedPushNotificationsModule = vi.hoisted(() => ({
+  enableNotifications: vi.fn(),
+  disableNotifications: vi.fn(),
+  pushNotificationsState: {
+    supported: true,
+    serverEnabled: true,
+    permission: "default",
+    subscribed: false,
+    locallyEnabled: false,
+    canRequestPermission: true,
+    busy: false,
+    error: null as string | null,
+    enable: undefined as unknown,
+    disable: undefined as unknown,
+  },
+}));
+mockedPushNotificationsModule.pushNotificationsState.enable =
+  mockedPushNotificationsModule.enableNotifications;
+mockedPushNotificationsModule.pushNotificationsState.disable =
+  mockedPushNotificationsModule.disableNotifications;
+
+const mockedDebugModule = vi.hoisted(() => ({
+  clearUserInputDebugEntries: vi.fn(),
+  setUserInputDebugCollapsed: vi.fn(),
+  setUserInputDebugEnabled: vi.fn(),
+  debugState: {
+    enabled: false,
+    entries: [] as Array<unknown>,
+  },
+}));
+
 vi.mock("../fork/settings", () => ({
   useForkSettings: () => ({
     ...mockedForkSettingsModule.forkSettingsState,
     updateForkSettings: mockedForkSettingsModule.updateForkSettings,
   }),
+}));
+
+vi.mock("../notifications/usePushNotifications", () => ({
+  usePushNotifications: () => mockedPushNotificationsModule.pushNotificationsState,
+}));
+
+vi.mock("../debug/userInputDebug", () => ({
+  clearUserInputDebugEntries: mockedDebugModule.clearUserInputDebugEntries,
+  setUserInputDebugCollapsed: mockedDebugModule.setUserInputDebugCollapsed,
+  setUserInputDebugEnabled: mockedDebugModule.setUserInputDebugEnabled,
+  useUserInputDebugStore: (selector: (state: typeof mockedDebugModule.debugState) => unknown) =>
+    selector(mockedDebugModule.debugState),
 }));
 
 import { ForkSettingsSection } from "./ForkSettingsSection";
@@ -48,17 +91,27 @@ describe("ForkSettingsSection", () => {
     mockedForkSettingsModule.forkSettingsState.settings.suppressCodexAppServerNotifications = false;
     mockedForkSettingsModule.forkSettingsState.defaults.pushNotificationsEnabled = false;
     mockedForkSettingsModule.forkSettingsState.defaults.suppressCodexAppServerNotifications = false;
+    mockedPushNotificationsModule.pushNotificationsState.error = null;
+    mockedPushNotificationsModule.pushNotificationsState.permission = "default";
+    mockedPushNotificationsModule.pushNotificationsState.subscribed = false;
+    mockedPushNotificationsModule.pushNotificationsState.locallyEnabled = false;
+    mockedPushNotificationsModule.pushNotificationsState.canRequestPermission = true;
+    mockedDebugModule.debugState.enabled = false;
+    mockedDebugModule.debugState.entries = [];
   });
 
-  it("renders the Codex session override control", async () => {
+  it("renders the fork settings controls", async () => {
     const mounted = await mountSection();
 
     try {
       await expect.element(page.getByRole("heading", { name: "Fork extensions" })).toBeVisible();
+      await expect.element(page.getByText("Push notifications")).toBeVisible();
       await expect.element(page.getByText("Suppress Codex native notifications")).toBeVisible();
+      await expect.element(page.getByRole("heading", { name: "Diagnostics" })).toBeVisible();
       await expect
         .element(page.getByLabelText("Suppress Codex native notifications"))
         .toBeInTheDocument();
+      await expect.element(page.getByLabelText("Open diagnostics panel")).toBeInTheDocument();
     } finally {
       await mounted.cleanup();
     }
@@ -72,6 +125,18 @@ describe("ForkSettingsSection", () => {
       expect(mockedForkSettingsModule.updateForkSettings).toHaveBeenCalledWith({
         suppressCodexAppServerNotifications: true,
       });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("opens the diagnostics panel from fork settings", async () => {
+    const mounted = await mountSection();
+
+    try {
+      await page.getByLabelText("Open diagnostics panel").click();
+      expect(mockedDebugModule.setUserInputDebugEnabled).toHaveBeenCalledWith(true);
+      expect(mockedDebugModule.setUserInputDebugCollapsed).toHaveBeenCalledWith(false);
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/settings/ForkSettingsSection.tsx
+++ b/apps/web/src/settings/ForkSettingsSection.tsx
@@ -1,5 +1,11 @@
 import { Button } from "../components/ui/button";
 import { Switch } from "../components/ui/switch";
+import {
+  clearUserInputDebugEntries,
+  setUserInputDebugCollapsed,
+  setUserInputDebugEnabled,
+  useUserInputDebugStore,
+} from "../debug/userInputDebug";
 import { useForkSettings } from "../fork/settings";
 import { usePushNotifications } from "../notifications/usePushNotifications";
 import {
@@ -11,6 +17,8 @@ import {
 export function ForkSettingsSection() {
   const { settings, defaults, updateForkSettings } = useForkSettings();
   const pushNotifications = usePushNotifications();
+  const userInputDebugEnabled = useUserInputDebugStore((store) => store.enabled);
+  const userInputDebugEntryCount = useUserInputDebugStore((store) => store.entries.length);
   const notificationsStatus = !pushNotifications.supported
     ? "This browser does not support PWA push notifications."
     : !pushNotifications.serverEnabled
@@ -110,6 +118,42 @@ export function ForkSettingsSection() {
             }
             aria-label="Suppress Codex native notifications"
           />
+        }
+      />
+
+      <SettingsRow
+        title="Diagnostics"
+        description="Open the fork-only debug sidecar for user-input breadcrumbs and crash diagnostics without editing the URL."
+        status={
+          userInputDebugEnabled
+            ? `Debug panel enabled with ${userInputDebugEntryCount} captured breadcrumb${userInputDebugEntryCount === 1 ? "" : "s"}.`
+            : "Debug panel currently hidden."
+        }
+        control={
+          <div className="flex w-full flex-wrap justify-end gap-2 sm:w-auto">
+            <Button
+              size="xs"
+              variant="outline"
+              aria-label="Open diagnostics panel"
+              onClick={() => {
+                setUserInputDebugEnabled(true);
+                setUserInputDebugCollapsed(false);
+              }}
+            >
+              {userInputDebugEnabled ? "Show panel" : "Open panel"}
+            </Button>
+            <Button
+              size="xs"
+              variant="ghost"
+              aria-label="Clear diagnostics breadcrumbs"
+              disabled={!userInputDebugEnabled && userInputDebugEntryCount === 0}
+              onClick={() => {
+                clearUserInputDebugEntries();
+              }}
+            >
+              Clear
+            </Button>
+          </div>
         }
       />
     </SettingsSection>

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -20,7 +20,7 @@ export default mergeConfig(
       strictPort: false,
     },
     test: {
-      include: ["src/components/**/*.browser.tsx"],
+      include: ["src/components/**/*.browser.tsx", "src/settings/**/*.browser.tsx"],
       browser: {
         enabled: true,
         provider: playwright(),


### PR DESCRIPTION
## Summary
- restore the fork-owned diagnostics sidecar, stores, and panel
- rebind root-sidecar mounting and crash breadcrumb lifecycle handling to the fresh upstream root
- wire user-input debug breadcrumbs and expired-question toasts into the modern runtime event path

## Verification
- bun fmt
- bun lint
- bun typecheck
- bun run --cwd apps/web test --run src/fork/bootstrap/rootDebug.test.ts src/debug/crashDebug.test.ts
- bun run --cwd apps/web test:browser --run src/settings/ForkSettingsSection.browser.tsx src/components/debug/ForkRootSidecars.browser.tsx

## Review
- parallel subagent code reviews completed with no remaining blockers in the final phase6 diff